### PR TITLE
Allow assembly to work on Windows Phone 8.1

### DIFF
--- a/Algolia.Search.sln
+++ b/Algolia.Search.sln
@@ -1,6 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
+# Visual Studio 2013
+VisualStudioVersion = 12.0.31101.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Algolia.Search", "Algolia.Search\Algolia.Search.csproj", "{693A4ED3-63CA-41A9-B3B5-06B4D52A5C70}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Algolia.Search.Test", "Algolia.Search.Test\Algolia.Search.Test.csproj", "{6943D1F8-3E73-4D8B-83F4-534314A1B2BC}"

--- a/Algolia.Search/Algolia.Search.csproj
+++ b/Algolia.Search/Algolia.Search.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>Algolia.Search</RootNamespace>
     <AssemblyName>Algolia.Search</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <TargetFrameworkProfile>Profile5</TargetFrameworkProfile>
+    <TargetFrameworkProfile>Profile92</TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>


### PR DESCRIPTION
The current assembly is incompatible with Windows Phone 8.1. I updated the project to target Windows Phone 8.1. The solution was also updated because you cannot develop Windows Phone 8.1 in Visual Studio 2012 or below.
