### PR TITLE
fix log parameter type

### DIFF
--- a/Algolia.Search/AlgoliaClient.cs
+++ b/Algolia.Search/AlgoliaClient.cs
@@ -416,9 +416,9 @@ namespace Algolia.Search
                         break;
                 }
                 if (param.Length == 0)
-                    param += string.Format("?onlyErrors={0}", type);
+                    param += string.Format("?type={0}", type);
                 else
-                    param += string.Format("&onlyErrors={0}", type);
+                    param += string.Format("&type={0}", type);
             }
             return ExecuteRequest(callType.Write, "GET", String.Format("/1/logs{0}", param), null, token);
         }


### PR DESCRIPTION
In this change b331b344f3f6a458a8c8187ffe442ae2089cc242 from
an onlyErrors option on the endpoint to type the parameter name
was not changed