### PR TITLE
Add request options as optional parameters to all methods

### DIFF
--- a/Algolia.Search.Test/AlgoliaClientTest.cs
+++ b/Algolia.Search.Test/AlgoliaClientTest.cs
@@ -1006,5 +1006,26 @@ namespace Algolia.Search.Test
 			//lastModified > _dsnInternalTimeout, retry on first host
 			Assert.Equal(JObject.Parse("{\"fromFirstHost\":[]}").ToString(), client.InitIndex("test").Browse().ToString());
 		}
-	}
+
+        [Fact]
+        public void TestRequestOptions()
+        {
+            ClearTest();
+
+            var attributesToRetrieve = new List<string> {"firstname"};
+            RequestOptions requestOptions = new RequestOptions();
+            requestOptions.SetForwardedFor("ForwardedFor");
+            requestOptions.AddExtraHeader("Header", "headerValue");
+            requestOptions.AddExtraQueryParameters("ExtraQueryParamKey", "ExtraQueryParamValue");
+
+            // A Request without url parameters 
+            var task = _index.AddObject(JObject.Parse(@"{""firstname"":""bob"", ""lastname"":""snow"", ""objectID"":""ananas""}"), null, requestOptions);
+            _index.WaitTask(task["taskID"].ToString());
+            // A request with url parameters
+            var res = _index.GetObject("ananas", attributesToRetrieve, requestOptions);
+
+            Assert.Equal("ananas", res["objectID"].ToString());
+            Assert.Equal("bob", res["firstname"].ToString());
+        }
+    }
 }

--- a/Algolia.Search.Test/AlgoliaClientTest.cs
+++ b/Algolia.Search.Test/AlgoliaClientTest.cs
@@ -900,7 +900,7 @@ namespace Algolia.Search.Test
 			_client.setTimeout(1, 1);
 			var startTime = DateTime.Now;
 			var index = _client.ListIndexes();
-			Assert.True((DateTime.Now - startTime).TotalSeconds < 3, DateTime.Now + " should have been less than or equal to" + startTime.AddSeconds(1) + " when testing the DNS timeout.");
+			Assert.True((DateTime.Now - startTime).TotalSeconds < 2, DateTime.Now + " should have been less than or equal to" + startTime.AddSeconds(1) + " when testing the DNS timeout.");
 		}
 
 		private void WaitKey(Index index, JObject newIndexKey, string updatedACL = null)

--- a/Algolia.Search.Test/AlgoliaClientTest.cs
+++ b/Algolia.Search.Test/AlgoliaClientTest.cs
@@ -900,7 +900,7 @@ namespace Algolia.Search.Test
 			_client.setTimeout(1, 1);
 			var startTime = DateTime.Now;
 			var index = _client.ListIndexes();
-			Assert.True(startTime.AddSeconds(1) < DateTime.Now, DateTime.Now + " should have been less than " + startTime.AddSeconds(1) + " when testing the DNS timeout.");
+			Assert.True(startTime.AddSeconds(1) <= DateTime.Now, DateTime.Now + " should have been less than or equal to" + startTime.AddSeconds(1) + " when testing the DNS timeout.");
 		}
 
 		private void WaitKey(Index index, JObject newIndexKey, string updatedACL = null)

--- a/Algolia.Search.Test/AlgoliaClientTest.cs
+++ b/Algolia.Search.Test/AlgoliaClientTest.cs
@@ -1007,25 +1007,25 @@ namespace Algolia.Search.Test
 			Assert.Equal(JObject.Parse("{\"fromFirstHost\":[]}").ToString(), client.InitIndex("test").Browse().ToString());
 		}
 
-        [Fact]
-        public void TestRequestOptions()
-        {
-            ClearTest();
+		[Fact]
+		public void TestRequestOptions()
+		{
+			ClearTest();
 
-            var attributesToRetrieve = new List<string> {"firstname"};
-            RequestOptions requestOptions = new RequestOptions();
-            requestOptions.SetForwardedFor("ForwardedFor");
-            requestOptions.AddExtraHeader("Header", "headerValue");
-            requestOptions.AddExtraQueryParameters("ExtraQueryParamKey", "ExtraQueryParamValue");
+			var attributesToRetrieve = new List<string> {"firstname"};
+			RequestOptions requestOptions = new RequestOptions();
+			requestOptions.SetForwardedFor("ForwardedFor");
+			requestOptions.AddExtraHeader("Header", "headerValue");
+			requestOptions.AddExtraQueryParameters("ExtraQueryParamKey", "ExtraQueryParamValue");
 
-            // A Request without url parameters 
-            var task = _index.AddObject(JObject.Parse(@"{""firstname"":""bob"", ""lastname"":""snow"", ""objectID"":""ananas""}"), null, requestOptions);
-            _index.WaitTask(task["taskID"].ToString());
-            // A request with url parameters
-            var res = _index.GetObject("ananas", attributesToRetrieve, requestOptions);
+			// A Request without url parameters 
+			var task = _index.AddObject(JObject.Parse(@"{""firstname"":""bob"", ""lastname"":""snow"", ""objectID"":""ananas""}"), null, requestOptions);
+			_index.WaitTask(task["taskID"].ToString());
+			// A request with url parameters
+			var res = _index.GetObject("ananas", attributesToRetrieve, requestOptions);
 
-            Assert.Equal("ananas", res["objectID"].ToString());
-            Assert.Equal("bob", res["firstname"].ToString());
-        }
-    }
+			Assert.Equal("ananas", res["objectID"].ToString());
+			Assert.Equal("bob", res["firstname"].ToString());
+		}
+	}
 }

--- a/Algolia.Search.Test/AlgoliaClientTest.cs
+++ b/Algolia.Search.Test/AlgoliaClientTest.cs
@@ -864,9 +864,9 @@ namespace Algolia.Search.Test
 			{
 				_client.ListIndexes();
 				_client = new AlgoliaClient(_testApplicationID, _testApiKey);
-                Assert.Throws<Exception>(() => {
+				Assert.Throws<Exception>(() => {
 					_index = _client.InitIndex(GetSafeName("àlgol?à-csharp"));
-                });
+				});
 			}
 			catch (AlgoliaException)
 			{
@@ -878,7 +878,7 @@ namespace Algolia.Search.Test
 			{
 				_client = new AlgoliaClient(_testApplicationID, _testApiKey);
 				_index = _client.InitIndex(GetSafeName("àlgol?à-csharp"));
-                Assert.Throws<AlgoliaException>(() =>
+				Assert.Throws<AlgoliaException>(() =>
 				{
 					_index = _client.InitIndex(GetSafeName("àlgol?à-csharp"));
 				});
@@ -900,7 +900,7 @@ namespace Algolia.Search.Test
 			_client.setTimeout(1, 1);
 			var startTime = DateTime.Now;
 			var index = _client.ListIndexes();
-			Assert.True(startTime.AddSeconds(1) < DateTime.Now);
+			Assert.True(startTime.AddSeconds(4) < DateTime.Now);
 		}
 
 		private void WaitKey(Index index, JObject newIndexKey, string updatedACL = null)

--- a/Algolia.Search.Test/AlgoliaClientTest.cs
+++ b/Algolia.Search.Test/AlgoliaClientTest.cs
@@ -1022,10 +1022,10 @@ namespace Algolia.Search.Test
 			requestOptions.AddExtraQueryParameters("ExtraQueryParamKey", "ExtraQueryParamValue");
 
 			// A Request without url parameters 
-			var task = _index.AddObject(JObject.Parse(@"{""firstname"":""bob"", ""lastname"":""snow"", ""objectID"":""ananas""}"), null, requestOptions);
+			var task = _index.AddObject(JObject.Parse(@"{""firstname"":""bob"", ""lastname"":""snow"", ""objectID"":""ananas""}"), requestOptions, null);
 			_index.WaitTask(task["taskID"].ToString());
 			// A request with url parameters
-			var res = _index.GetObject("ananas", attributesToRetrieve, requestOptions);
+			var res = _index.GetObject("ananas", requestOptions, attributesToRetrieve);
 
 			Assert.Equal("ananas", res["objectID"].ToString());
 			Assert.Equal("bob", res["firstname"].ToString());

--- a/Algolia.Search.Test/AlgoliaClientTest.cs
+++ b/Algolia.Search.Test/AlgoliaClientTest.cs
@@ -900,7 +900,7 @@ namespace Algolia.Search.Test
 			_client.setTimeout(1, 1);
 			var startTime = DateTime.Now;
 			var index = _client.ListIndexes();
-			Assert.True(startTime.AddSeconds(1) <= DateTime.Now, DateTime.Now + " should have been less than or equal to" + startTime.AddSeconds(1) + " when testing the DNS timeout.");
+			Assert.True((DateTime.Now - startTime).TotalSeconds < 3, DateTime.Now + " should have been less than or equal to" + startTime.AddSeconds(1) + " when testing the DNS timeout.");
 		}
 
 		private void WaitKey(Index index, JObject newIndexKey, string updatedACL = null)

--- a/Algolia.Search.Test/AlgoliaClientTest.cs
+++ b/Algolia.Search.Test/AlgoliaClientTest.cs
@@ -900,7 +900,7 @@ namespace Algolia.Search.Test
 			_client.setTimeout(1, 1);
 			var startTime = DateTime.Now;
 			var index = _client.ListIndexes();
-			Assert.True((DateTime.Now - startTime).TotalSeconds < 2, DateTime.Now + " should have been less than or equal to" + startTime.AddSeconds(1) + " when testing the DNS timeout.");
+			Assert.True((DateTime.Now - startTime).TotalSeconds < 2);
 		}
 
 		private void WaitKey(Index index, JObject newIndexKey, string updatedACL = null)

--- a/Algolia.Search.Test/AlgoliaClientTest.cs
+++ b/Algolia.Search.Test/AlgoliaClientTest.cs
@@ -864,9 +864,9 @@ namespace Algolia.Search.Test
 			{
 				_client.ListIndexes();
 				_client = new AlgoliaClient(_testApplicationID, _testApiKey);
-				Assert.Throws<Exception>(() => {
+                Assert.Throws<Exception>(() => {
 					_index = _client.InitIndex(GetSafeName("àlgol?à-csharp"));
-				});
+                });
 			}
 			catch (AlgoliaException)
 			{
@@ -878,7 +878,7 @@ namespace Algolia.Search.Test
 			{
 				_client = new AlgoliaClient(_testApplicationID, _testApiKey);
 				_index = _client.InitIndex(GetSafeName("àlgol?à-csharp"));
-				Assert.Throws<AlgoliaException>(() =>
+                Assert.Throws<AlgoliaException>(() =>
 				{
 					_index = _client.InitIndex(GetSafeName("àlgol?à-csharp"));
 				});
@@ -900,7 +900,7 @@ namespace Algolia.Search.Test
 			_client.setTimeout(1, 1);
 			var startTime = DateTime.Now;
 			var index = _client.ListIndexes();
-			Assert.True(startTime.AddSeconds(4) < DateTime.Now);
+			Assert.True(startTime.AddSeconds(1) < DateTime.Now);
 		}
 
 		private void WaitKey(Index index, JObject newIndexKey, string updatedACL = null)

--- a/Algolia.Search.Test/AlgoliaClientTest.cs
+++ b/Algolia.Search.Test/AlgoliaClientTest.cs
@@ -900,7 +900,7 @@ namespace Algolia.Search.Test
 			_client.setTimeout(1, 1);
 			var startTime = DateTime.Now;
 			var index = _client.ListIndexes();
-			Assert.True(startTime.AddSeconds(1) < DateTime.Now);
+			Assert.True(startTime.AddSeconds(1) < DateTime.Now, DateTime.Now + " should have been less than " + startTime.AddSeconds(1) + " when testing the DNS timeout.");
 		}
 
 		private void WaitKey(Index index, JObject newIndexKey, string updatedACL = null)

--- a/Algolia.Search.Test/AlgoliaClientTest.cs
+++ b/Algolia.Search.Test/AlgoliaClientTest.cs
@@ -901,7 +901,7 @@ namespace Algolia.Search.Test
 			var startTime = DateTime.Now;
 			var index = _client.ListIndexes();
 			Assert.True((DateTime.Now - startTime).TotalSeconds < 2);
-			Assert.IsNotNull(index);
+			Assert.True(index != null);
 		}
 
 		private void WaitKey(Index index, JObject newIndexKey, string updatedACL = null)

--- a/Algolia.Search.Test/AlgoliaClientTest.cs
+++ b/Algolia.Search.Test/AlgoliaClientTest.cs
@@ -901,6 +901,7 @@ namespace Algolia.Search.Test
 			var startTime = DateTime.Now;
 			var index = _client.ListIndexes();
 			Assert.True((DateTime.Now - startTime).TotalSeconds < 2);
+			Assert.IsNotNull(index);
 		}
 
 		private void WaitKey(Index index, JObject newIndexKey, string updatedACL = null)

--- a/Algolia.Search.Test/BaseTest.cs
+++ b/Algolia.Search.Test/BaseTest.cs
@@ -36,6 +36,7 @@ namespace Algolia.Search.Test
 			try
 			{
 				_index.ClearIndex();
+				_index.ClearRules();
 			}
 			catch (Exception)
 			{

--- a/Algolia.Search/Algolia.Search.csproj
+++ b/Algolia.Search/Algolia.Search.csproj
@@ -13,8 +13,8 @@
         <PackageLicenseUrl>https://github.com/algolia/algoliasearch-client-csharp/blob/master/LICENSE.TXT</PackageLicenseUrl>
         <RepositoryType>git</RepositoryType>
         <RepositoryUrl>https://github.com/algolia/algoliasearch-client-csharp</RepositoryUrl>
-        <Version>4.1.0</Version>
-        <AssemblyVersion>4.1.0</AssemblyVersion>
+        <Version>4.1.1</Version>
+        <AssemblyVersion>4.1.1</AssemblyVersion>
         <FileVersion>3.8.0.0</FileVersion>
         <TargetFrameworks>net46;net462;netcoreapp1.1;netcoreapp1.0;netstandard1.6;netstandard1.3;</TargetFrameworks>
     </PropertyGroup>

--- a/Algolia.Search/Algolia.Search.csproj
+++ b/Algolia.Search/Algolia.Search.csproj
@@ -13,8 +13,8 @@
         <PackageLicenseUrl>https://github.com/algolia/algoliasearch-client-csharp/blob/master/LICENSE.TXT</PackageLicenseUrl>
         <RepositoryType>git</RepositoryType>
         <RepositoryUrl>https://github.com/algolia/algoliasearch-client-csharp</RepositoryUrl>
-        <Version>4.0.1</Version>
-        <AssemblyVersion>4.0.1</AssemblyVersion>
+        <Version>4.1.0</Version>
+        <AssemblyVersion>4.1.0</AssemblyVersion>
         <FileVersion>3.8.0.0</FileVersion>
         <TargetFrameworks>net46;net462;netcoreapp1.1;netcoreapp1.0;netstandard1.6;netstandard1.3;</TargetFrameworks>
     </PropertyGroup>

--- a/Algolia.Search/Algolia.Search.csproj
+++ b/Algolia.Search/Algolia.Search.csproj
@@ -13,8 +13,8 @@
         <PackageLicenseUrl>https://github.com/algolia/algoliasearch-client-csharp/blob/master/LICENSE.TXT</PackageLicenseUrl>
         <RepositoryType>git</RepositoryType>
         <RepositoryUrl>https://github.com/algolia/algoliasearch-client-csharp</RepositoryUrl>
-        <Version>4.0.1-beta</Version>
-        <AssemblyVersion>4.0.1-beta</AssemblyVersion>
+        <Version>4.0.1</Version>
+        <AssemblyVersion>4.0.1</AssemblyVersion>
         <FileVersion>3.8.0.0</FileVersion>
         <TargetFrameworks>net46;net462;netcoreapp1.1;netcoreapp1.0;netstandard1.6;netstandard1.3;</TargetFrameworks>
     </PropertyGroup>

--- a/Algolia.Search/Algolia.Search.csproj
+++ b/Algolia.Search/Algolia.Search.csproj
@@ -13,8 +13,8 @@
         <PackageLicenseUrl>https://github.com/algolia/algoliasearch-client-csharp/blob/master/LICENSE.TXT</PackageLicenseUrl>
         <RepositoryType>git</RepositoryType>
         <RepositoryUrl>https://github.com/algolia/algoliasearch-client-csharp</RepositoryUrl>
-        <Version>4.0.0</Version>
-        <AssemblyVersion>4.0.0</AssemblyVersion>
+        <Version>4.0.1-beta</Version>
+        <AssemblyVersion>4.0.1-beta</AssemblyVersion>
         <FileVersion>3.8.0.0</FileVersion>
         <TargetFrameworks>net46;net462;netcoreapp1.1;netcoreapp1.0;netstandard1.6;netstandard1.3;</TargetFrameworks>
     </PropertyGroup>

--- a/Algolia.Search/AlgoliaClient.cs
+++ b/Algolia.Search/AlgoliaClient.cs
@@ -230,7 +230,7 @@ namespace Algolia.Search
         /// <param name="queries">List of queries per index</param>
         /// <param name="strategy">Strategy applied on the sequence of queries</param>
         /// <returns></returns>
-        public Task<JObject> MultipleQueriesAsync(List<IndexQuery> queries, string strategy = "none", CancellationToken token = default(CancellationToken))
+        public Task<JObject> MultipleQueriesAsync(List<IndexQuery> queries, string strategy = "none", CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
             List<Dictionary<string, object>> body = new List<Dictionary<string, object>>();
             foreach (IndexQuery indexQuery in queries)
@@ -243,7 +243,7 @@ namespace Algolia.Search
             Dictionary<string, object> requests = new Dictionary<string, object>();
             requests.Add("requests", body);
             requests.Add("strategy", strategy);
-            return ExecuteRequest(callType.Search, "POST", "/1/indexes/*/queries", requests, token);
+            return ExecuteRequest(callType.Search, "POST", "/1/indexes/*/queries", requests, token, requestOptions);
 
         }
 
@@ -252,9 +252,9 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="queries">List of queries per index</param>
         /// <returns></returns>
-        public JObject MultipleQueries(List<IndexQuery> queries, string strategy = "none", CancellationToken token = default(CancellationToken))
+        public JObject MultipleQueries(List<IndexQuery> queries, string strategy = "none", CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
-            return MultipleQueriesAsync(queries, strategy).GetAwaiter().GetResult();
+            return MultipleQueriesAsync(queries, strategy, token, requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -264,9 +264,9 @@ namespace Algolia.Search
         ///    {"items": [ {"name": "contacts", "createdAt": "2013-01-18T15:33:13.556Z"},
         ///                {"name": "notes", "createdAt": "2013-01-18T15:33:13.556Z"} ] }
         /// </returns>
-        public Task<JObject> ListIndexesAsync(CancellationToken token = default(CancellationToken))
+        public Task<JObject> ListIndexesAsync(CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
-            return ExecuteRequest(callType.Read, "GET", "/1/indexes/", null, token);
+            return ExecuteRequest(callType.Read, "GET", "/1/indexes/", null, token, requestOptions);
         }
 
         /// <summary>
@@ -276,9 +276,9 @@ namespace Algolia.Search
         ///    {"items": [ {"name": "contacts", "createdAt": "2013-01-18T15:33:13.556Z"},
         ///                {"name": "notes", "createdAt": "2013-01-18T15:33:13.556Z"} ] }
         /// </returns>
-        public JObject ListIndexes()
+        public JObject ListIndexes(RequestOptions requestOptions = null)
         {
-            return ListIndexesAsync().GetAwaiter().GetResult();
+            return ListIndexesAsync(default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -286,18 +286,18 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="indexName">The name of index to delete</param>
         /// <returns>An object containing a "deletedAt" attribute</returns>
-        public Task<JObject> DeleteIndexAsync(string indexName, CancellationToken token = default(CancellationToken))
+        public Task<JObject> DeleteIndexAsync(string indexName, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
-            return ExecuteRequest(callType.Write, "DELETE", "/1/indexes/" + WebUtility.UrlEncode(indexName), null, token);
+            return ExecuteRequest(callType.Write, "DELETE", "/1/indexes/" + WebUtility.UrlEncode(indexName), null, token, requestOptions);
         }
 
         /// <summary>
         /// Synchronously call <see cref="AlgoliaClient.DeleteIndexAsync"/> 
         /// </summary>
         /// <returns>An object containing a "deletedAt" attribute</returns>
-        public JObject DeleteIndex(string indexName)
+        public JObject DeleteIndex(string indexName, RequestOptions requestOptions = null)
         {
-            return DeleteIndexAsync(indexName).GetAwaiter().GetResult();
+            return DeleteIndexAsync(indexName, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -305,21 +305,21 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="srcIndexName">The name of index to move.</param>
         /// <param name="dstIndexName">The new index name that will contain a copy of srcIndexName (destination will be overriten if it already exists).</param>
-        public Task<JObject> MoveIndexAsync(string srcIndexName, string dstIndexName, CancellationToken token = default(CancellationToken))
+        public Task<JObject> MoveIndexAsync(string srcIndexName, string dstIndexName, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
             Dictionary<string, object> operation = new Dictionary<string, object>();
             operation["operation"] = "move";
             operation["destination"] = dstIndexName;
-            return ExecuteRequest(callType.Write, "POST", string.Format("/1/indexes/{0}/operation", WebUtility.UrlEncode(srcIndexName)), operation, token);
+            return ExecuteRequest(callType.Write, "POST", string.Format("/1/indexes/{0}/operation", WebUtility.UrlEncode(srcIndexName)), operation, token, requestOptions);
         }
         /// <summary>
         /// Synchronously call <see cref="AlgoliaClient.MoveIndexAsync"/>
         /// </summary>
         /// <param name="srcIndexName">The name of index to move.</param>
         /// <param name="dstIndexName">The new index name that will contain a copy of srcIndexName (destination will be overriten if it already exists).</param>
-        public JObject MoveIndex(string srcIndexName, string dstIndexName)
+        public JObject MoveIndex(string srcIndexName, string dstIndexName, RequestOptions requestOptions = null)
         {
-            return MoveIndexAsync(srcIndexName, dstIndexName).GetAwaiter().GetResult();
+            return MoveIndexAsync(srcIndexName, dstIndexName, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -327,21 +327,21 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="srcIndexName">The name of index to copy.</param>
         /// <param name="dstIndexName">The new index name that will contain a copy of srcIndexName (destination will be overriten if it already exists).</param>
-        public Task<JObject> CopyIndexAsync(string srcIndexName, string dstIndexName, CancellationToken token = default(CancellationToken))
+        public Task<JObject> CopyIndexAsync(string srcIndexName, string dstIndexName, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
             Dictionary<string, object> operation = new Dictionary<string, object>();
             operation["operation"] = "copy";
             operation["destination"] = dstIndexName;
-            return ExecuteRequest(callType.Write, "POST", string.Format("/1/indexes/{0}/operation", WebUtility.UrlEncode(srcIndexName)), operation, token);
+            return ExecuteRequest(callType.Write, "POST", string.Format("/1/indexes/{0}/operation", WebUtility.UrlEncode(srcIndexName)), operation, token, requestOptions);
         }
         /// <summary>
         /// Synchronously call <see cref="AlgoliaClient.CopyIndexAsync"/> 
         /// </summary>
         /// <param name="srcIndexName">The name of index to copy.</param>
         /// <param name="dstIndexName">The new index name that will contain a copy of srcIndexName (destination will be overriten if it already exists).</param>
-        public JObject CopyIndex(string srcIndexName, string dstIndexName)
+        public JObject CopyIndex(string srcIndexName, string dstIndexName, RequestOptions requestOptions = null)
         {
-            return CopyIndexAsync(srcIndexName, dstIndexName).GetAwaiter().GetResult();
+            return CopyIndexAsync(srcIndexName, dstIndexName, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -373,9 +373,9 @@ namespace Algolia.Search
         /// <param name="offset">Specify the first entry to retrieve (0-based, 0 is the most recent log entry).</param>
         /// <param name="length">Specify the maximum number of entries to retrieve starting at offset. Maximum allowed value: 1000.</param>
         /// <param name="onlyErrors">If set to true, the answer will only contain API calls with errors.</param>
-        public Task<JObject> GetLogsAsync(int offset = 0, int length = 10, bool onlyErrors = false)
+        public Task<JObject> GetLogsAsync(int offset = 0, int length = 10, bool onlyErrors = false, RequestOptions requestOptions = null)
         {
-            return GetLogsAsync(offset, length, onlyErrors ? LogType.LOG_ERROR : LogType.LOG_ALL);
+            return GetLogsAsync(offset, length, onlyErrors ? LogType.LOG_ERROR : LogType.LOG_ALL, default(CancellationToken), requestOptions);
         }
 
         /// <summary>
@@ -384,7 +384,7 @@ namespace Algolia.Search
         /// <param name="offset">Specify the first entry to retrieve (0-based, 0 is the most recent log entry).</param>
         /// <param name="length">Specify the maximum number of entries to retrieve starting at offset. Maximum allowed value: 1000.</param>
         /// <param name="logType">Specify the type of logs to include.</param>
-        public Task<JObject> GetLogsAsync(int offset = 0, int length = 10, LogType logType = LogType.LOG_ALL, CancellationToken token = default(CancellationToken))
+        public Task<JObject> GetLogsAsync(int offset = 0, int length = 10, LogType logType = LogType.LOG_ALL, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
             string param = "";
             if (offset != 0)
@@ -420,7 +420,7 @@ namespace Algolia.Search
                 else
                     param += string.Format("&type={0}", type);
             }
-            return ExecuteRequest(callType.Write, "GET", String.Format("/1/logs{0}", param), null, token);
+            return ExecuteRequest(callType.Write, "GET", String.Format("/1/logs{0}", param), null, token, requestOptions);
         }
 
         /// <summary>
@@ -429,9 +429,9 @@ namespace Algolia.Search
         /// <param name="offset">Specify the first entry to retrieve (0-based, 0 is the most recent log entry).</param>
         /// <param name="length">Specify the maximum number of entries to retrieve starting at offset. Maximum allowed value: 1000.</param>
         /// <param name="onlyErrors">If set to true, the answer will only contain API calls with errors.</param>
-        public JObject GetLogs(int offset = 0, int length = 10, bool onlyErrors = false)
+        public JObject GetLogs(int offset = 0, int length = 10, bool onlyErrors = false, RequestOptions requestOptions = null)
         {
-            return GetLogsAsync(offset, length, onlyErrors).GetAwaiter().GetResult();
+            return GetLogsAsync(offset, length, onlyErrors, requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -440,9 +440,9 @@ namespace Algolia.Search
         /// <param name="offset">Specify the first entry to retrieve (0-based, 0 is the most recent log entry).</param>
         /// <param name="length">Specify the maximum number of entries to retrieve starting at offset. Maximum allowed value: 1000.</param>
         /// <param name="logType">Specify the type of logs to include.</param>
-        public JObject GetLogs(int offset, int length, LogType logType)
+        public JObject GetLogs(int offset, int length, LogType logType, RequestOptions requestOptions = null)
         {
-            return GetLogsAsync(offset, length, logType).GetAwaiter().GetResult();
+            return GetLogsAsync(offset, length, logType, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -450,7 +450,7 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="indexName">The name of the index</param>
         /// <returns>An instance of the Index object that exposes Index actions</returns>
-        public Index InitIndex(string indexName)
+        public Index InitIndex(string indexName, RequestOptions requestOptions = null)
         {
             return new Index(this, indexName);
         }
@@ -460,18 +460,18 @@ namespace Algolia.Search
         /// </summary>
         /// <returns>An object containing the list of keys.</returns>
         [Obsolete("ListUserKeysAsync is deprecated, please use ListApiKeysAsync instead.")]
-        public Task<JObject> ListUserKeysAsync(CancellationToken token = default(CancellationToken))
+        public Task<JObject> ListUserKeysAsync(CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
-            return ExecuteRequest(callType.Read, "GET", "/1/keys", null, token);
+            return ExecuteRequest(callType.Read, "GET", "/1/keys", null, token, requestOptions);
         }
 
         /// <summary>
         /// List all existing api keys with their associated ACLs.
         /// </summary>
         /// <returns>An object containing the list of keys.</returns>
-        public Task<JObject> ListApiKeysAsync(CancellationToken token = default(CancellationToken))
+        public Task<JObject> ListApiKeysAsync(CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
-            return ExecuteRequest(callType.Read, "GET", "/1/keys", null, token);
+            return ExecuteRequest(callType.Read, "GET", "/1/keys", null, token, requestOptions);
         }
 
         /// <summary>
@@ -479,18 +479,18 @@ namespace Algolia.Search
         /// </summary>
         /// <returns>An object containing the list of keys.</returns>
         [Obsolete("ListUserKeys is deprecated, please use ListApiKeys instead.")]
-        public JObject ListUserKeys()
+        public JObject ListUserKeys(RequestOptions requestOptions = null)
         {
-            return ListApiKeysAsync().GetAwaiter().GetResult();
+            return ListApiKeysAsync(default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Synchronously call <see cref="AlgoliaClient.ListApiKeysAsync"/> 
         /// </summary>
         /// <returns>An object containing the list of keys.</returns>
-        public JObject ListApiKeys()
+        public JObject ListApiKeys(RequestOptions requestOptions = null)
         {
-            return ListApiKeysAsync().GetAwaiter().GetResult();
+            return ListApiKeysAsync(default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -498,18 +498,18 @@ namespace Algolia.Search
         /// </summary>
         /// <returns>Returns an object with an "acls" array containing an array of strings with rights.</returns>
         [Obsolete("GetUserKeyACLAsync is deprecated, please use GetApiKeyACLAsync instead.")]
-        public Task<JObject> GetUserKeyACLAsync(string key, CancellationToken token = default(CancellationToken))
+        public Task<JObject> GetUserKeyACLAsync(string key, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
-            return ExecuteRequest(callType.Read, "GET", "/1/keys/" + key, null, token);
+            return ExecuteRequest(callType.Read, "GET", "/1/keys/" + key, null, token, requestOptions);
         }
 
         /// <summary>
         /// Get ACL for an existing api key.
         /// </summary>
         /// <returns>Returns an object with an "acls" array containing an array of strings with rights.</returns>
-        public Task<JObject> GetApiKeyACLAsync(string key, CancellationToken token = default(CancellationToken))
+        public Task<JObject> GetApiKeyACLAsync(string key, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
-            return ExecuteRequest(callType.Read, "GET", "/1/keys/" + key, null, token);
+            return ExecuteRequest(callType.Read, "GET", "/1/keys/" + key, null, token, requestOptions);
         }
 
         /// <summary>
@@ -517,18 +517,18 @@ namespace Algolia.Search
         /// </summary>
         /// <returns>Returns an object with an "acls" array containing an array of strings with rights.</returns>
         [Obsolete("GetUserKeyACL is deprecated, please use GetApiKeyACL instead.")]
-        public JObject GetUserKeyACL(string key)
+        public JObject GetUserKeyACL(string key, RequestOptions requestOptions = null)
         {
-            return GetApiKeyACLAsync(key).GetAwaiter().GetResult();
+            return GetApiKeyACLAsync(key, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Synchronously call <see cref="AlgoliaClient.GetApiKeyACLAsync"/> 
         /// </summary>
         /// <returns>Returns an object with an "acls" array containing an array of strings with rights.</returns>
-        public JObject GetApiKeyACL(string key)
+        public JObject GetApiKeyACL(string key, RequestOptions requestOptions = null)
         {
-            return GetApiKeyACLAsync(key).GetAwaiter().GetResult();
+            return GetApiKeyACLAsync(key, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -536,18 +536,18 @@ namespace Algolia.Search
         /// </summary>
         /// <returns>Returns an object with a "deleteAt" attribute.</returns>
         [Obsolete("DeleteUserKeyAsync is deprecated, please use DeleteApiKeyAsync instead.")]
-        public Task<JObject> DeleteUserKeyAsync(string key, CancellationToken token = default(CancellationToken))
+        public Task<JObject> DeleteUserKeyAsync(string key, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
-            return ExecuteRequest(callType.Write, "DELETE", "/1/keys/" + key, null, token);
+            return ExecuteRequest(callType.Write, "DELETE", "/1/keys/" + key, null, token, requestOptions);
         }
 
         /// <summary>
         /// Delete an existing user key.
         /// </summary>
         /// <returns>Returns an object with a "deleteAt" attribute.</returns>
-        public Task<JObject> DeleteApiKeyAsync(string key, CancellationToken token = default(CancellationToken))
+        public Task<JObject> DeleteApiKeyAsync(string key, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
-            return ExecuteRequest(callType.Write, "DELETE", "/1/keys/" + key, null, token);
+            return ExecuteRequest(callType.Write, "DELETE", "/1/keys/" + key, null, token, requestOptions);
         }
 
         /// <summary>
@@ -555,18 +555,18 @@ namespace Algolia.Search
         /// </summary>
         /// <returns>Returns an object with a "deleteAt" attribute.</returns>
         [Obsolete("DeleteUserKey is deprecated, please use DeleteApiKey instead.")]
-        public JObject DeleteUserKey(string key)
+        public JObject DeleteUserKey(string key, RequestOptions requestOptions = null)
         {
-            return DeleteApiKeyAsync(key).GetAwaiter().GetResult();
+            return DeleteApiKeyAsync(key, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Synchronously call <see cref="AlgoliaClient.DeleteApiKeyAsync"/> 
         /// </summary>
         /// <returns>Returns an object with a "deleteAt" attribute.</returns>
-        public JObject DeleteApiKey(string key)
+        public JObject DeleteApiKey(string key, RequestOptions requestOptions = null)
         {
-            return DeleteApiKeyAsync(key).GetAwaiter().GetResult();
+            return DeleteApiKeyAsync(key, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -584,9 +584,9 @@ namespace Algolia.Search
         ///   - maxQueriesPerIPPerHour: integer
         /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
         [Obsolete("AddUserKeyAsync is deprecated, please use AddApiKeyAsync instead.")]
-        public Task<JObject> AddUserKeyAsync(Dictionary<string, object> parameters, CancellationToken token = default(CancellationToken))
+        public Task<JObject> AddUserKeyAsync(Dictionary<string, object> parameters, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
-            return ExecuteRequest(callType.Write, "POST", "/1/keys", parameters, token);
+            return ExecuteRequest(callType.Write, "POST", "/1/keys", parameters, token, requestOptions);
         }
 
         /// <summary>
@@ -603,9 +603,9 @@ namespace Algolia.Search
         ///   - queryParameters: string
         ///   - maxQueriesPerIPPerHour: integer
         /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
-        public Task<JObject> AddApiKeyAsync(Dictionary<string, object> parameters, CancellationToken token = default(CancellationToken))
+        public Task<JObject> AddApiKeyAsync(Dictionary<string, object> parameters, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
-            return ExecuteRequest(callType.Write, "POST", "/1/keys", parameters, token);
+            return ExecuteRequest(callType.Write, "POST", "/1/keys", parameters, token, requestOptions);
         }
 
         /// <summary>
@@ -623,9 +623,9 @@ namespace Algolia.Search
         ///   - maxQueriesPerIPPerHour: integer
         /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
         [Obsolete("AddUserKey is deprecated, please use AddApiKey instead.")]
-        public JObject AddUserKey(Dictionary<string, object> parameters)
+        public JObject AddUserKey(Dictionary<string, object> parameters, RequestOptions requestOptions = null)
         {
-            return AddApiKeyAsync(parameters).GetAwaiter().GetResult();
+            return AddApiKeyAsync(parameters, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -642,9 +642,9 @@ namespace Algolia.Search
         ///   - queryParameters: string
         ///   - maxQueriesPerIPPerHour: integer
         /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
-        public JObject AddApiKey(Dictionary<string, object> parameters)
+        public JObject AddApiKey(Dictionary<string, object> parameters, RequestOptions requestOptions = null)
         {
-            return AddApiKeyAsync(parameters).GetAwaiter().GetResult();
+            return AddApiKeyAsync(parameters, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -663,7 +663,7 @@ namespace Algolia.Search
         /// <param name="indexes">Restrict the new API key to specific index names.</param>
         /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
         [Obsolete("AddUserKeyAsync is deprecated, please use AddApiKeyAsync instead.")]
-        public Task<JObject> AddUserKeyAsync(IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, IEnumerable<string> indexes = null)
+        public Task<JObject> AddUserKeyAsync(IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, IEnumerable<string> indexes = null, RequestOptions requestOptions = null)
         {
             if (indexes == null)
             {
@@ -675,7 +675,7 @@ namespace Algolia.Search
             content["maxQueriesPerIPPerHour"] = maxQueriesPerIPPerHour;
             content["maxHitsPerQuery"] = maxHitsPerQuery;
             content["indexes"] = indexes;
-            return AddApiKeyAsync(content);
+            return AddApiKeyAsync(content, default(CancellationToken), requestOptions);
         }
 
         /// <summary>
@@ -693,7 +693,7 @@ namespace Algolia.Search
         /// <param name="maxHitsPerQuery">Specify the maximum number of hits this API key can retrieve in one call. Defaults to 0 (unlimited).</param>
         /// <param name="indexes">Restrict the new API key to specific index names.</param>
         /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
-        public Task<JObject> AddApiKeyAsync(IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, IEnumerable<string> indexes = null)
+        public Task<JObject> AddApiKeyAsync(IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, IEnumerable<string> indexes = null, RequestOptions requestOptions = null)
         {
             if (indexes == null)
             {
@@ -705,7 +705,7 @@ namespace Algolia.Search
             content["maxQueriesPerIPPerHour"] = maxQueriesPerIPPerHour;
             content["maxHitsPerQuery"] = maxHitsPerQuery;
             content["indexes"] = indexes;
-            return AddApiKeyAsync(content);
+            return AddApiKeyAsync(content, default(CancellationToken), requestOptions);
         }
 
         /// <summary>
@@ -724,9 +724,9 @@ namespace Algolia.Search
         /// <param name="indexes">Restrict the new API key to specific index names.</param>
         /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
         [Obsolete("AddUserKey is deprecated, please use AddApiKey instead.")]
-        public JObject AddUserKey(IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, IEnumerable<string> indexes = null)
+        public JObject AddUserKey(IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, IEnumerable<string> indexes = null, RequestOptions requestOptions = null)
         {
-            return AddApiKeyAsync(acls, validity, maxQueriesPerIPPerHour, maxHitsPerQuery, indexes).GetAwaiter().GetResult();
+            return AddApiKeyAsync(acls, validity, maxQueriesPerIPPerHour, maxHitsPerQuery, indexes, requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -744,9 +744,9 @@ namespace Algolia.Search
         /// <param name="maxHitsPerQuery">Specify the maximum number of hits this API key can retrieve in one call. Defaults to 0 (unlimited).</param>
         /// <param name="indexes">Restrict the new API key to specific index names.</param>
         /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
-        public JObject AddApiKey(IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, IEnumerable<string> indexes = null)
+        public JObject AddApiKey(IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, IEnumerable<string> indexes = null, RequestOptions requestOptions = null)
         {
-            return AddApiKeyAsync(acls, validity, maxQueriesPerIPPerHour, maxHitsPerQuery, indexes).GetAwaiter().GetResult();
+            return AddApiKeyAsync(acls, validity, maxQueriesPerIPPerHour, maxHitsPerQuery, indexes, requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -765,9 +765,9 @@ namespace Algolia.Search
         ///   - maxQueriesPerIPPerHour: integer
         /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
         [Obsolete("UpdateUserKeyAsync is deprecated, please use UpdateApiKeyAsync instead.")]
-        public Task<JObject> UpdateUserKeyAsync(string key, Dictionary<string, object> parameters, CancellationToken token = default(CancellationToken))
+        public Task<JObject> UpdateUserKeyAsync(string key, Dictionary<string, object> parameters, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
-            return ExecuteRequest(callType.Write, "PUT", "/1/keys/" + key, parameters, token);
+            return ExecuteRequest(callType.Write, "PUT", "/1/keys/" + key, parameters, token, requestOptions);
         }
 
         /// <summary>
@@ -785,9 +785,9 @@ namespace Algolia.Search
         ///   - queryParameters: string
         ///   - maxQueriesPerIPPerHour: integer
         /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
-        public Task<JObject> UpdateApiKeyAsync(string key, Dictionary<string, object> parameters, CancellationToken token = default(CancellationToken))
+        public Task<JObject> UpdateApiKeyAsync(string key, Dictionary<string, object> parameters, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
-            return ExecuteRequest(callType.Write, "PUT", "/1/keys/" + key, parameters, token);
+            return ExecuteRequest(callType.Write, "PUT", "/1/keys/" + key, parameters, token, requestOptions);
         }
 
         /// <summary>
@@ -806,9 +806,9 @@ namespace Algolia.Search
         ///   - maxQueriesPerIPPerHour: integer
         /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
         [Obsolete("UpdateUserKey is deprecated, please use UpdateApiKey instead.")]
-        public JObject UpdateUserKey(string key, Dictionary<string, object> parameters)
+        public JObject UpdateUserKey(string key, Dictionary<string, object> parameters, RequestOptions requestOptions = null)
         {
-            return UpdateApiKeyAsync(key, parameters).GetAwaiter().GetResult();
+            return UpdateApiKeyAsync(key, parameters, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -826,9 +826,9 @@ namespace Algolia.Search
         ///   - queryParameters: string
         ///   - maxQueriesPerIPPerHour: integer
         /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
-        public JObject UpdateApiKey(string key, Dictionary<string, object> parameters)
+        public JObject UpdateApiKey(string key, Dictionary<string, object> parameters, RequestOptions requestOptions = null)
         {
-            return UpdateApiKeyAsync(key, parameters).GetAwaiter().GetResult();
+            return UpdateApiKeyAsync(key, parameters, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -848,7 +848,7 @@ namespace Algolia.Search
         /// <param name="indexes">Restrict the new API key to specific index names.</param>
         /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
         [Obsolete("UpdateUserKeyAsync is deprecated, please use UpdateApiKeyAsync instead.")]
-        public Task<JObject> UpdateUserKeyAsync(string key, IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, IEnumerable<string> indexes = null)
+        public Task<JObject> UpdateUserKeyAsync(string key, IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, IEnumerable<string> indexes = null, RequestOptions requestOptions = null)
         {
             if (indexes == null)
             {
@@ -860,7 +860,7 @@ namespace Algolia.Search
             content["maxQueriesPerIPPerHour"] = maxQueriesPerIPPerHour;
             content["maxHitsPerQuery"] = maxHitsPerQuery;
             content["indexes"] = indexes;
-            return UpdateApiKeyAsync(key, content);
+            return UpdateApiKeyAsync(key, content, default(CancellationToken), requestOptions);
         }
 
         /// <summary>
@@ -879,7 +879,7 @@ namespace Algolia.Search
         /// <param name="maxHitsPerQuery">Specify the maximum number of hits this API key can retrieve in one call. Defaults to 0 (unlimited).</param>
         /// <param name="indexes">Restrict the new API key to specific index names.</param>
         /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
-        public Task<JObject> UpdateApiKeyAsync(string key, IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, IEnumerable<string> indexes = null)
+        public Task<JObject> UpdateApiKeyAsync(string key, IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, IEnumerable<string> indexes = null, RequestOptions requestOptions = null)
         {
             if (indexes == null)
             {
@@ -891,7 +891,7 @@ namespace Algolia.Search
             content["maxQueriesPerIPPerHour"] = maxQueriesPerIPPerHour;
             content["maxHitsPerQuery"] = maxHitsPerQuery;
             content["indexes"] = indexes;
-            return UpdateApiKeyAsync(key, content);
+            return UpdateApiKeyAsync(key, content, default(CancellationToken), requestOptions);
         }
 
         /// <summary>
@@ -911,9 +911,9 @@ namespace Algolia.Search
         /// <param name="indexes">Restrict the new API key to specific index names.</param>
         /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
         [Obsolete("UpdateUserKey is deprecated, please use UpdateApiKey instead.")]
-        public JObject UpdateUserKey(string key, IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, IEnumerable<string> indexes = null)
+        public JObject UpdateUserKey(string key, IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, IEnumerable<string> indexes = null, RequestOptions requestOptions = null)
         {
-            return UpdateApiKeyAsync(key, acls, validity, maxQueriesPerIPPerHour, maxHitsPerQuery, indexes).GetAwaiter().GetResult();
+            return UpdateApiKeyAsync(key, acls, validity, maxQueriesPerIPPerHour, maxHitsPerQuery, indexes, requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -932,9 +932,9 @@ namespace Algolia.Search
         /// <param name="maxHitsPerQuery">Specify the maximum number of hits this API key can retrieve in one call. Defaults to 0 (unlimited).</param>
         /// <param name="indexes">Restrict the new API key to specific index names.</param>
         /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
-        public JObject UpdateApiKey(string key, IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, IEnumerable<string> indexes = null)
+        public JObject UpdateApiKey(string key, IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, IEnumerable<string> indexes = null, RequestOptions requestOptions = null)
         {
-            return UpdateApiKeyAsync(key, acls, validity, maxQueriesPerIPPerHour, maxHitsPerQuery, indexes).GetAwaiter().GetResult();
+            return UpdateApiKeyAsync(key, acls, validity, maxQueriesPerIPPerHour, maxHitsPerQuery, indexes, requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -942,11 +942,11 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="actions">An array of action to send.</param>
         /// <returns>An object containing an "objectIDs" attribute (array of string) and a dictionary for the taskIDs.</returns>
-        public Task<JObject> BatchAsync(IEnumerable<object> requests, CancellationToken token = default(CancellationToken))
+        public Task<JObject> BatchAsync(IEnumerable<object> requests, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
             Dictionary<string, object> batch = new Dictionary<string, object>();
             batch["requests"] = requests;
-            return ExecuteRequest(AlgoliaClient.callType.Write, "POST", "/1/indexes/*/batch", batch, token);
+            return ExecuteRequest(AlgoliaClient.callType.Write, "POST", "/1/indexes/*/batch", batch, token, requestOptions);
         }
 
         /// <summary>
@@ -954,9 +954,9 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="actions">An array of action to send.</param>
         /// <returns>An object containing an "objectIDs" attribute (array of string) and a dictionary for the taskIDs.</returns>
-        public JObject Batch(IEnumerable<object> requests)
+        public JObject Batch(IEnumerable<object> requests, RequestOptions requestOptions = null)
         {
-            return BatchAsync(requests).GetAwaiter().GetResult();
+            return BatchAsync(requests, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
 
 
@@ -1076,6 +1076,7 @@ namespace Algolia.Search
         /// <param name="method">HTTP method</param>
         /// <param name="requestUrl">URL to request</param>
         /// <param name="content">The content</param>
+        /// <param name="requestOptions">The additional request options</param>
         /// <returns></returns>
         public async Task<JObject> ExecuteRequest(callType type, string method, string requestUrl, object content, CancellationToken token, RequestOptions requestOptions = null)
         {

--- a/Algolia.Search/AlgoliaClient.cs
+++ b/Algolia.Search/AlgoliaClient.cs
@@ -1128,12 +1128,20 @@ namespace Algolia.Search
                                 break;
                             case "POST":
                                 httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, url);
-                                httpRequestMessage.Content = new StringContent(Newtonsoft.Json.JsonConvert.SerializeObject(content));
-                                break;
+	                            if (content != null)
+	                            {
+		                            httpRequestMessage.Content =
+			                            new StringContent(Newtonsoft.Json.JsonConvert.SerializeObject(content));
+	                            }
+	                            break;
                             case "PUT":
                                 httpRequestMessage = new HttpRequestMessage(HttpMethod.Put, url);
-                                httpRequestMessage.Content = new StringContent(Newtonsoft.Json.JsonConvert.SerializeObject(content));
-                                break;
+	                            if (content != null)
+	                            {
+		                            httpRequestMessage.Content =
+			                            new StringContent(Newtonsoft.Json.JsonConvert.SerializeObject(content));
+	                            }
+	                            break;
                             case "DELETE":
                                 httpRequestMessage = new HttpRequestMessage(HttpMethod.Delete, url);
                                 break;

--- a/Algolia.Search/AlgoliaClient.cs
+++ b/Algolia.Search/AlgoliaClient.cs
@@ -228,9 +228,11 @@ namespace Algolia.Search
         /// This method allows querying multiple indexes with one API call
         /// </summary>
         /// <param name="queries">List of queries per index</param>
+        /// <param name="requestOptions"></param>
         /// <param name="strategy">Strategy applied on the sequence of queries</param>
+        /// <param name="token"></param>
         /// <returns></returns>
-        public Task<JObject> MultipleQueriesAsync(List<IndexQuery> queries, string strategy = "none", CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        public Task<JObject> MultipleQueriesAsync(List<IndexQuery> queries, RequestOptions requestOptions, string strategy = "none", CancellationToken token = default(CancellationToken))
         {
             List<Dictionary<string, object>> body = new List<Dictionary<string, object>>();
             foreach (IndexQuery indexQuery in queries)
@@ -251,10 +253,13 @@ namespace Algolia.Search
         /// Synchronously call <see cref="AlgoliaClient.MultipleQueriesAsync"/>
         /// </summary>
         /// <param name="queries">List of queries per index</param>
+        /// <param name="requestOptions"></param>
+        /// <param name="strategy"></param>
+        /// <param name="token"></param>
         /// <returns></returns>
-        public JObject MultipleQueries(List<IndexQuery> queries, string strategy = "none", CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        public JObject MultipleQueries(List<IndexQuery> queries, RequestOptions requestOptions, string strategy = "none", CancellationToken token = default(CancellationToken))
         {
-            return MultipleQueriesAsync(queries, strategy, token, requestOptions).GetAwaiter().GetResult();
+            return MultipleQueriesAsync(queries, requestOptions, strategy, token).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -264,7 +269,7 @@ namespace Algolia.Search
         ///    {"items": [ {"name": "contacts", "createdAt": "2013-01-18T15:33:13.556Z"},
         ///                {"name": "notes", "createdAt": "2013-01-18T15:33:13.556Z"} ] }
         /// </returns>
-        public Task<JObject> ListIndexesAsync(CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        public Task<JObject> ListIndexesAsync(RequestOptions requestOptions, CancellationToken token = default(CancellationToken))
         {
             return ExecuteRequest(callType.Read, "GET", "/1/indexes/", null, token, requestOptions);
         }
@@ -276,17 +281,19 @@ namespace Algolia.Search
         ///    {"items": [ {"name": "contacts", "createdAt": "2013-01-18T15:33:13.556Z"},
         ///                {"name": "notes", "createdAt": "2013-01-18T15:33:13.556Z"} ] }
         /// </returns>
-        public JObject ListIndexes(RequestOptions requestOptions = null)
+        public JObject ListIndexes(RequestOptions requestOptions)
         {
-            return ListIndexesAsync(default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return ListIndexesAsync(requestOptions, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Delete an index.
         /// </summary>
         /// <param name="indexName">The name of index to delete</param>
+        /// <param name="requestOptions"></param>
+        /// <param name="token"></param>
         /// <returns>An object containing a "deletedAt" attribute</returns>
-        public Task<JObject> DeleteIndexAsync(string indexName, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        public Task<JObject> DeleteIndexAsync(string indexName, RequestOptions requestOptions, CancellationToken token = default(CancellationToken))
         {
             return ExecuteRequest(callType.Write, "DELETE", "/1/indexes/" + WebUtility.UrlEncode(indexName), null, token, requestOptions);
         }
@@ -295,9 +302,9 @@ namespace Algolia.Search
         /// Synchronously call <see cref="AlgoliaClient.DeleteIndexAsync"/> 
         /// </summary>
         /// <returns>An object containing a "deletedAt" attribute</returns>
-        public JObject DeleteIndex(string indexName, RequestOptions requestOptions = null)
+        public JObject DeleteIndex(string indexName, RequestOptions requestOptions)
         {
-            return DeleteIndexAsync(indexName, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return DeleteIndexAsync(indexName, requestOptions, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -305,21 +312,25 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="srcIndexName">The name of index to move.</param>
         /// <param name="dstIndexName">The new index name that will contain a copy of srcIndexName (destination will be overriten if it already exists).</param>
-        public Task<JObject> MoveIndexAsync(string srcIndexName, string dstIndexName, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        /// <param name="requestOptions"></param>
+        /// <param name="token"></param>
+        public Task<JObject> MoveIndexAsync(string srcIndexName, string dstIndexName, RequestOptions requestOptions, CancellationToken token = default(CancellationToken))
         {
             Dictionary<string, object> operation = new Dictionary<string, object>();
             operation["operation"] = "move";
             operation["destination"] = dstIndexName;
             return ExecuteRequest(callType.Write, "POST", string.Format("/1/indexes/{0}/operation", WebUtility.UrlEncode(srcIndexName)), operation, token, requestOptions);
         }
+
         /// <summary>
         /// Synchronously call <see cref="AlgoliaClient.MoveIndexAsync"/>
         /// </summary>
         /// <param name="srcIndexName">The name of index to move.</param>
         /// <param name="dstIndexName">The new index name that will contain a copy of srcIndexName (destination will be overriten if it already exists).</param>
-        public JObject MoveIndex(string srcIndexName, string dstIndexName, RequestOptions requestOptions = null)
+        /// <param name="requestOptions"></param>
+        public JObject MoveIndex(string srcIndexName, string dstIndexName, RequestOptions requestOptions)
         {
-            return MoveIndexAsync(srcIndexName, dstIndexName, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return MoveIndexAsync(srcIndexName, dstIndexName, requestOptions, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -327,7 +338,9 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="srcIndexName">The name of index to copy.</param>
         /// <param name="dstIndexName">The new index name that will contain a copy of srcIndexName (destination will be overriten if it already exists).</param>
-        public Task<JObject> CopyIndexAsync(string srcIndexName, string dstIndexName, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        /// <param name="requestOptions"></param>
+        /// <param name="token"></param>
+        public Task<JObject> CopyIndexAsync(string srcIndexName, string dstIndexName, RequestOptions requestOptions, CancellationToken token = default(CancellationToken))
         {
             Dictionary<string, object> operation = new Dictionary<string, object>();
             operation["operation"] = "copy";
@@ -339,9 +352,9 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="srcIndexName">The name of index to copy.</param>
         /// <param name="dstIndexName">The new index name that will contain a copy of srcIndexName (destination will be overriten if it already exists).</param>
-        public JObject CopyIndex(string srcIndexName, string dstIndexName, RequestOptions requestOptions = null)
+        public JObject CopyIndex(string srcIndexName, string dstIndexName, RequestOptions requestOptions)
         {
-            return CopyIndexAsync(srcIndexName, dstIndexName, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return CopyIndexAsync(srcIndexName, dstIndexName, requestOptions, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -373,18 +386,20 @@ namespace Algolia.Search
         /// <param name="offset">Specify the first entry to retrieve (0-based, 0 is the most recent log entry).</param>
         /// <param name="length">Specify the maximum number of entries to retrieve starting at offset. Maximum allowed value: 1000.</param>
         /// <param name="onlyErrors">If set to true, the answer will only contain API calls with errors.</param>
-        public Task<JObject> GetLogsAsync(int offset = 0, int length = 10, bool onlyErrors = false, RequestOptions requestOptions = null)
+        public Task<JObject> GetLogsAsync(RequestOptions requestOptions, int offset = 0, int length = 10, bool onlyErrors = false)
         {
-            return GetLogsAsync(offset, length, onlyErrors ? LogType.LOG_ERROR : LogType.LOG_ALL, default(CancellationToken), requestOptions);
+            return GetLogsAsync(requestOptions, offset, length, onlyErrors ? LogType.LOG_ERROR : LogType.LOG_ALL, default(CancellationToken));
         }
 
         /// <summary>
         /// Return last logs entries.
         /// </summary>
+        /// <param name="requestOptions"></param>
         /// <param name="offset">Specify the first entry to retrieve (0-based, 0 is the most recent log entry).</param>
         /// <param name="length">Specify the maximum number of entries to retrieve starting at offset. Maximum allowed value: 1000.</param>
         /// <param name="logType">Specify the type of logs to include.</param>
-        public Task<JObject> GetLogsAsync(int offset = 0, int length = 10, LogType logType = LogType.LOG_ALL, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        /// <param name="token"></param>
+        public Task<JObject> GetLogsAsync(RequestOptions requestOptions, int offset = 0, int length = 10, LogType logType = LogType.LOG_ALL, CancellationToken token = default(CancellationToken))
         {
             string param = "";
             if (offset != 0)
@@ -426,12 +441,13 @@ namespace Algolia.Search
         /// <summary>
         /// Synchronously call <see cref="AlgoliaClient.GetLogsAsync(int, int, bool)"/>
         /// </summary>
+        /// <param name="requestOptions"></param>
         /// <param name="offset">Specify the first entry to retrieve (0-based, 0 is the most recent log entry).</param>
         /// <param name="length">Specify the maximum number of entries to retrieve starting at offset. Maximum allowed value: 1000.</param>
         /// <param name="onlyErrors">If set to true, the answer will only contain API calls with errors.</param>
-        public JObject GetLogs(int offset = 0, int length = 10, bool onlyErrors = false, RequestOptions requestOptions = null)
+        public JObject GetLogs(RequestOptions requestOptions, int offset = 0, int length = 10, bool onlyErrors = false)
         {
-            return GetLogsAsync(offset, length, onlyErrors, requestOptions).GetAwaiter().GetResult();
+            return GetLogsAsync(requestOptions, offset, length, onlyErrors).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -440,9 +456,10 @@ namespace Algolia.Search
         /// <param name="offset">Specify the first entry to retrieve (0-based, 0 is the most recent log entry).</param>
         /// <param name="length">Specify the maximum number of entries to retrieve starting at offset. Maximum allowed value: 1000.</param>
         /// <param name="logType">Specify the type of logs to include.</param>
-        public JObject GetLogs(int offset, int length, LogType logType, RequestOptions requestOptions = null)
+        /// <param name="requestOptions"></param>
+        public JObject GetLogs(int offset, int length, LogType logType, RequestOptions requestOptions)
         {
-            return GetLogsAsync(offset, length, logType, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return GetLogsAsync(requestOptions, offset, length, logType, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -450,7 +467,7 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="indexName">The name of the index</param>
         /// <returns>An instance of the Index object that exposes Index actions</returns>
-        public Index InitIndex(string indexName, RequestOptions requestOptions = null)
+        public Index InitIndex(string indexName)
         {
             return new Index(this, indexName);
         }
@@ -460,7 +477,7 @@ namespace Algolia.Search
         /// </summary>
         /// <returns>An object containing the list of keys.</returns>
         [Obsolete("ListUserKeysAsync is deprecated, please use ListApiKeysAsync instead.")]
-        public Task<JObject> ListUserKeysAsync(CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        public Task<JObject> ListUserKeysAsync(RequestOptions requestOptions, CancellationToken token = default(CancellationToken))
         {
             return ExecuteRequest(callType.Read, "GET", "/1/keys", null, token, requestOptions);
         }
@@ -469,7 +486,7 @@ namespace Algolia.Search
         /// List all existing api keys with their associated ACLs.
         /// </summary>
         /// <returns>An object containing the list of keys.</returns>
-        public Task<JObject> ListApiKeysAsync(CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        public Task<JObject> ListApiKeysAsync(RequestOptions requestOptions, CancellationToken token = default(CancellationToken))
         {
             return ExecuteRequest(callType.Read, "GET", "/1/keys", null, token, requestOptions);
         }
@@ -479,18 +496,18 @@ namespace Algolia.Search
         /// </summary>
         /// <returns>An object containing the list of keys.</returns>
         [Obsolete("ListUserKeys is deprecated, please use ListApiKeys instead.")]
-        public JObject ListUserKeys(RequestOptions requestOptions = null)
+        public JObject ListUserKeys(RequestOptions requestOptions)
         {
-            return ListApiKeysAsync(default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return ListApiKeysAsync(requestOptions, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Synchronously call <see cref="AlgoliaClient.ListApiKeysAsync"/> 
         /// </summary>
         /// <returns>An object containing the list of keys.</returns>
-        public JObject ListApiKeys(RequestOptions requestOptions = null)
+        public JObject ListApiKeys(RequestOptions requestOptions)
         {
-            return ListApiKeysAsync(default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return ListApiKeysAsync(requestOptions, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -498,7 +515,7 @@ namespace Algolia.Search
         /// </summary>
         /// <returns>Returns an object with an "acls" array containing an array of strings with rights.</returns>
         [Obsolete("GetUserKeyACLAsync is deprecated, please use GetApiKeyACLAsync instead.")]
-        public Task<JObject> GetUserKeyACLAsync(string key, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        public Task<JObject> GetUserKeyACLAsync(string key, RequestOptions requestOptions, CancellationToken token = default(CancellationToken))
         {
             return ExecuteRequest(callType.Read, "GET", "/1/keys/" + key, null, token, requestOptions);
         }
@@ -507,7 +524,7 @@ namespace Algolia.Search
         /// Get ACL for an existing api key.
         /// </summary>
         /// <returns>Returns an object with an "acls" array containing an array of strings with rights.</returns>
-        public Task<JObject> GetApiKeyACLAsync(string key, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        public Task<JObject> GetApiKeyACLAsync(string key, RequestOptions requestOptions, CancellationToken token = default(CancellationToken))
         {
             return ExecuteRequest(callType.Read, "GET", "/1/keys/" + key, null, token, requestOptions);
         }
@@ -517,18 +534,18 @@ namespace Algolia.Search
         /// </summary>
         /// <returns>Returns an object with an "acls" array containing an array of strings with rights.</returns>
         [Obsolete("GetUserKeyACL is deprecated, please use GetApiKeyACL instead.")]
-        public JObject GetUserKeyACL(string key, RequestOptions requestOptions = null)
+        public JObject GetUserKeyACL(string key, RequestOptions requestOptions)
         {
-            return GetApiKeyACLAsync(key, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return GetApiKeyACLAsync(key, requestOptions, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Synchronously call <see cref="AlgoliaClient.GetApiKeyACLAsync"/> 
         /// </summary>
         /// <returns>Returns an object with an "acls" array containing an array of strings with rights.</returns>
-        public JObject GetApiKeyACL(string key, RequestOptions requestOptions = null)
+        public JObject GetApiKeyACL(string key, RequestOptions requestOptions)
         {
-            return GetApiKeyACLAsync(key, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return GetApiKeyACLAsync(key, requestOptions, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -536,7 +553,7 @@ namespace Algolia.Search
         /// </summary>
         /// <returns>Returns an object with a "deleteAt" attribute.</returns>
         [Obsolete("DeleteUserKeyAsync is deprecated, please use DeleteApiKeyAsync instead.")]
-        public Task<JObject> DeleteUserKeyAsync(string key, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        public Task<JObject> DeleteUserKeyAsync(string key, RequestOptions requestOptions, CancellationToken token = default(CancellationToken))
         {
             return ExecuteRequest(callType.Write, "DELETE", "/1/keys/" + key, null, token, requestOptions);
         }
@@ -545,7 +562,7 @@ namespace Algolia.Search
         /// Delete an existing user key.
         /// </summary>
         /// <returns>Returns an object with a "deleteAt" attribute.</returns>
-        public Task<JObject> DeleteApiKeyAsync(string key, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        public Task<JObject> DeleteApiKeyAsync(string key, RequestOptions requestOptions, CancellationToken token = default(CancellationToken))
         {
             return ExecuteRequest(callType.Write, "DELETE", "/1/keys/" + key, null, token, requestOptions);
         }
@@ -555,36 +572,38 @@ namespace Algolia.Search
         /// </summary>
         /// <returns>Returns an object with a "deleteAt" attribute.</returns>
         [Obsolete("DeleteUserKey is deprecated, please use DeleteApiKey instead.")]
-        public JObject DeleteUserKey(string key, RequestOptions requestOptions = null)
+        public JObject DeleteUserKey(string key, RequestOptions requestOptions)
         {
-            return DeleteApiKeyAsync(key, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return DeleteApiKeyAsync(key, requestOptions, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Synchronously call <see cref="AlgoliaClient.DeleteApiKeyAsync"/> 
         /// </summary>
         /// <returns>Returns an object with a "deleteAt" attribute.</returns>
-        public JObject DeleteApiKey(string key, RequestOptions requestOptions = null)
+        public JObject DeleteApiKey(string key, RequestOptions requestOptions)
         {
-            return DeleteApiKeyAsync(key, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return DeleteApiKeyAsync(key, requestOptions, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Create a new user key.
         /// </summary>
         /// <param name="parameters">the list of parameters for this key. Defined by a Dictionnary that 
-        /// can contains the following values:
-        ///   - acl: array of string
-        ///   - indices: array of string
-        ///   - validity: int
-        ///   - referers: array of string
-        ///   - description: string
-        ///   - maxHitsPerQuery: integer
-        ///   - queryParameters: string
-        ///   - maxQueriesPerIPPerHour: integer
-        /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
+        ///     can contains the following values:
+        ///     - acl: array of string
+        ///     - indices: array of string
+        ///     - validity: int
+        ///     - referers: array of string
+        ///     - description: string
+        ///     - maxHitsPerQuery: integer
+        ///     - queryParameters: string
+        ///     - maxQueriesPerIPPerHour: integer
+        ///     <returns>Returns an object with a "key" string attribute containing the new key.</returns>
+        /// <param name="requestOptions"></param>
+        /// <param name="token"></param>
         [Obsolete("AddUserKeyAsync is deprecated, please use AddApiKeyAsync instead.")]
-        public Task<JObject> AddUserKeyAsync(Dictionary<string, object> parameters, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        public Task<JObject> AddUserKeyAsync(Dictionary<string, object> parameters, RequestOptions requestOptions, CancellationToken token = default(CancellationToken))
         {
             return ExecuteRequest(callType.Write, "POST", "/1/keys", parameters, token, requestOptions);
         }
@@ -593,17 +612,19 @@ namespace Algolia.Search
         /// Create a new api key.
         /// </summary>
         /// <param name="parameters">the list of parameters for this key. Defined by a Dictionnary that 
-        /// can contains the following values:
-        ///   - acl: array of string
-        ///   - indices: array of string
-        ///   - validity: int
-        ///   - referers: array of string
-        ///   - description: string
-        ///   - maxHitsPerQuery: integer
-        ///   - queryParameters: string
-        ///   - maxQueriesPerIPPerHour: integer
-        /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
-        public Task<JObject> AddApiKeyAsync(Dictionary<string, object> parameters, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        ///     can contains the following values:
+        ///     - acl: array of string
+        ///     - indices: array of string
+        ///     - validity: int
+        ///     - referers: array of string
+        ///     - description: string
+        ///     - maxHitsPerQuery: integer
+        ///     - queryParameters: string
+        ///     - maxQueriesPerIPPerHour: integer
+        ///     <returns>Returns an object with a "key" string attribute containing the new key.</returns>
+        /// <param name="requestOptions"></param>
+        /// <param name="token"></param>
+        public Task<JObject> AddApiKeyAsync(Dictionary<string, object> parameters, RequestOptions requestOptions, CancellationToken token = default(CancellationToken))
         {
             return ExecuteRequest(callType.Write, "POST", "/1/keys", parameters, token, requestOptions);
         }
@@ -612,58 +633,61 @@ namespace Algolia.Search
         /// Synchronously call <see cref="AlgoliaClient.AddApiKeyAsync"/>
         /// </summary>
         /// <param name="parameters">the list of parameters for this key. Defined by a Dictionnary that 
-        /// can contains the following values:
-        ///   - acl: array of string
-        ///   - indices: array of string
-        ///   - validity: int
-        ///   - referers: array of string
-        ///   - description: string
-        ///   - maxHitsPerQuery: integer
-        ///   - queryParameters: string
-        ///   - maxQueriesPerIPPerHour: integer
-        /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
+        ///     can contains the following values:
+        ///     - acl: array of string
+        ///     - indices: array of string
+        ///     - validity: int
+        ///     - referers: array of string
+        ///     - description: string
+        ///     - maxHitsPerQuery: integer
+        ///     - queryParameters: string
+        ///     - maxQueriesPerIPPerHour: integer
+        ///     <returns>Returns an object with a "key" string attribute containing the new key.</returns>
+        /// <param name="requestOptions"></param>
         [Obsolete("AddUserKey is deprecated, please use AddApiKey instead.")]
-        public JObject AddUserKey(Dictionary<string, object> parameters, RequestOptions requestOptions = null)
+        public JObject AddUserKey(Dictionary<string, object> parameters, RequestOptions requestOptions)
         {
-            return AddApiKeyAsync(parameters, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return AddApiKeyAsync(parameters, requestOptions, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Synchronously call <see cref="AlgoliaClient.AddApiKeyAsync"/>
         /// </summary>
         /// <param name="parameters">the list of parameters for this key. Defined by a Dictionnary that 
-        /// can contains the following values:
-        ///   - acl: array of string
-        ///   - indices: array of string
-        ///   - validity: int
-        ///   - referers: array of string
-        ///   - description: string
-        ///   - maxHitsPerQuery: integer
-        ///   - queryParameters: string
-        ///   - maxQueriesPerIPPerHour: integer
-        /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
-        public JObject AddApiKey(Dictionary<string, object> parameters, RequestOptions requestOptions = null)
+        ///     can contains the following values:
+        ///     - acl: array of string
+        ///     - indices: array of string
+        ///     - validity: int
+        ///     - referers: array of string
+        ///     - description: string
+        ///     - maxHitsPerQuery: integer
+        ///     - queryParameters: string
+        ///     - maxQueriesPerIPPerHour: integer
+        ///     <returns>Returns an object with a "key" string attribute containing the new key.</returns>
+        /// <param name="requestOptions"></param>
+        public JObject AddApiKey(Dictionary<string, object> parameters, RequestOptions requestOptions)
         {
-            return AddApiKeyAsync(parameters, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return AddApiKeyAsync(parameters, requestOptions, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Create a new user key.
         /// </summary>
         /// <param name="acls">The list of ACL for this key. Defined by an array of strings that can contains the following values:
-        ///   - search: allow searching (https and http)
-        ///   - addObject: allow adding/updating an object in the index (https only)
-        ///   - deleteObject : allow deleting an existing object (https only)
-        ///   - deleteIndex : allow deleting an index (https only)
-        ///   - settings : allow getting index settings (https only)
-        ///   - editSettings : allow changing index settings (https only)</param>
+        ///     - search: allow searching (https and http)
+        ///     - addObject: allow adding/updating an object in the index (https only)
+        ///     - deleteObject : allow deleting an existing object (https only)
+        ///     - deleteIndex : allow deleting an index (https only)
+        ///     - settings : allow getting index settings (https only)
+        ///     - editSettings : allow changing index settings (https only)</param>
+        /// <param name="requestOptions"></param>
         /// <param name="validity">The number of seconds after which the key will be automatically removed (0 means no time limit for this key).</param>
         /// <param name="maxQueriesPerIPPerHour">Specify the maximum number of API calls allowed from an IP address per hour.  Defaults to 0 (no rate limit).</param>
         /// <param name="maxHitsPerQuery">Specify the maximum number of hits this API key can retrieve in one call. Defaults to 0 (unlimited).</param>
         /// <param name="indexes">Restrict the new API key to specific index names.</param>
         /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
         [Obsolete("AddUserKeyAsync is deprecated, please use AddApiKeyAsync instead.")]
-        public Task<JObject> AddUserKeyAsync(IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, IEnumerable<string> indexes = null, RequestOptions requestOptions = null)
+        public Task<JObject> AddUserKeyAsync(IEnumerable<string> acls, RequestOptions requestOptions, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, IEnumerable<string> indexes = null)
         {
             if (indexes == null)
             {
@@ -675,25 +699,26 @@ namespace Algolia.Search
             content["maxQueriesPerIPPerHour"] = maxQueriesPerIPPerHour;
             content["maxHitsPerQuery"] = maxHitsPerQuery;
             content["indexes"] = indexes;
-            return AddApiKeyAsync(content, default(CancellationToken), requestOptions);
+            return AddApiKeyAsync(content, requestOptions, default(CancellationToken));
         }
 
         /// <summary>
         /// Create a new api key.
         /// </summary>
         /// <param name="acls">The list of ACL for this key. Defined by an array of strings that can contains the following values:
-        ///   - search: allow searching (https and http)
-        ///   - addObject: allow adding/updating an object in the index (https only)
-        ///   - deleteObject : allow deleting an existing object (https only)
-        ///   - deleteIndex : allow deleting an index (https only)
-        ///   - settings : allow getting index settings (https only)
-        ///   - editSettings : allow changing index settings (https only)</param>
+        ///     - search: allow searching (https and http)
+        ///     - addObject: allow adding/updating an object in the index (https only)
+        ///     - deleteObject : allow deleting an existing object (https only)
+        ///     - deleteIndex : allow deleting an index (https only)
+        ///     - settings : allow getting index settings (https only)
+        ///     - editSettings : allow changing index settings (https only)</param>
+        /// <param name="requestOptions"></param>
         /// <param name="validity">The number of seconds after which the key will be automatically removed (0 means no time limit for this key).</param>
         /// <param name="maxQueriesPerIPPerHour">Specify the maximum number of API calls allowed from an IP address per hour.  Defaults to 0 (no rate limit).</param>
         /// <param name="maxHitsPerQuery">Specify the maximum number of hits this API key can retrieve in one call. Defaults to 0 (unlimited).</param>
         /// <param name="indexes">Restrict the new API key to specific index names.</param>
         /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
-        public Task<JObject> AddApiKeyAsync(IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, IEnumerable<string> indexes = null, RequestOptions requestOptions = null)
+        public Task<JObject> AddApiKeyAsync(IEnumerable<string> acls, RequestOptions requestOptions, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, IEnumerable<string> indexes = null)
         {
             if (indexes == null)
             {
@@ -705,48 +730,50 @@ namespace Algolia.Search
             content["maxQueriesPerIPPerHour"] = maxQueriesPerIPPerHour;
             content["maxHitsPerQuery"] = maxHitsPerQuery;
             content["indexes"] = indexes;
-            return AddApiKeyAsync(content, default(CancellationToken), requestOptions);
+            return AddApiKeyAsync(content, requestOptions, default(CancellationToken));
         }
 
         /// <summary>
         /// Synchronously call <see cref="AlgoliaClient.AddApiKeyAsync"/>
         /// </summary>
         /// <param name="acls">The list of ACL for this key. Defined by an array of strings that can contains the following values:
-        ///   - search: allow searching (https and http)
-        ///   - addObject: allow adding/updating an object in the index (https only)
-        ///   - deleteObject : allow deleting an existing object (https only)
-        ///   - deleteIndex : allow deleting an index (https only)
-        ///   - settings : allow getting index settings (https only)
-        ///   - editSettings : allow changing index settings (https only)</param>
+        ///     - search: allow searching (https and http)
+        ///     - addObject: allow adding/updating an object in the index (https only)
+        ///     - deleteObject : allow deleting an existing object (https only)
+        ///     - deleteIndex : allow deleting an index (https only)
+        ///     - settings : allow getting index settings (https only)
+        ///     - editSettings : allow changing index settings (https only)</param>
+        /// <param name="requestOptions"></param>
         /// <param name="validity">The number of seconds after which the key will be automatically removed (0 means no time limit for this key).</param>
         /// <param name="maxQueriesPerIPPerHour">Specify the maximum number of API calls allowed from an IP address per hour.  Defaults to 0 (no rate limit).</param>
         /// <param name="maxHitsPerQuery">Specify the maximum number of hits this API key can retrieve in one call. Defaults to 0 (unlimited).</param>
         /// <param name="indexes">Restrict the new API key to specific index names.</param>
         /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
         [Obsolete("AddUserKey is deprecated, please use AddApiKey instead.")]
-        public JObject AddUserKey(IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, IEnumerable<string> indexes = null, RequestOptions requestOptions = null)
+        public JObject AddUserKey(IEnumerable<string> acls, RequestOptions requestOptions, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, IEnumerable<string> indexes = null)
         {
-            return AddApiKeyAsync(acls, validity, maxQueriesPerIPPerHour, maxHitsPerQuery, indexes, requestOptions).GetAwaiter().GetResult();
+            return AddApiKeyAsync(acls, requestOptions, validity, maxQueriesPerIPPerHour, maxHitsPerQuery, indexes).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Synchronously call <see cref="AlgoliaClient.AddApiKeyAsync"/>
         /// </summary>
         /// <param name="acls">The list of ACL for this key. Defined by an array of strings that can contains the following values:
-        ///   - search: allow searching (https and http)
-        ///   - addObject: allow adding/updating an object in the index (https only)
-        ///   - deleteObject : allow deleting an existing object (https only)
-        ///   - deleteIndex : allow deleting an index (https only)
-        ///   - settings : allow getting index settings (https only)
-        ///   - editSettings : allow changing index settings (https only)</param>
+        ///     - search: allow searching (https and http)
+        ///     - addObject: allow adding/updating an object in the index (https only)
+        ///     - deleteObject : allow deleting an existing object (https only)
+        ///     - deleteIndex : allow deleting an index (https only)
+        ///     - settings : allow getting index settings (https only)
+        ///     - editSettings : allow changing index settings (https only)</param>
+        /// <param name="requestOptions"></param>
         /// <param name="validity">The number of seconds after which the key will be automatically removed (0 means no time limit for this key).</param>
         /// <param name="maxQueriesPerIPPerHour">Specify the maximum number of API calls allowed from an IP address per hour.  Defaults to 0 (no rate limit).</param>
         /// <param name="maxHitsPerQuery">Specify the maximum number of hits this API key can retrieve in one call. Defaults to 0 (unlimited).</param>
         /// <param name="indexes">Restrict the new API key to specific index names.</param>
         /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
-        public JObject AddApiKey(IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, IEnumerable<string> indexes = null, RequestOptions requestOptions = null)
+        public JObject AddApiKey(IEnumerable<string> acls, RequestOptions requestOptions, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, IEnumerable<string> indexes = null)
         {
-            return AddApiKeyAsync(acls, validity, maxQueriesPerIPPerHour, maxHitsPerQuery, indexes, requestOptions).GetAwaiter().GetResult();
+            return AddApiKeyAsync(acls, requestOptions, validity, maxQueriesPerIPPerHour, maxHitsPerQuery, indexes).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -754,18 +781,20 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="key">The user key</param>
         /// <param name="parameters">the list of parameters for this key. Defined by a Dictionnary that 
-        /// can contains the following values:
-        ///   - acl: array of string
-        ///   - indices: array of string
-        ///   - validity: int
-        ///   - referers: array of string
-        ///   - description: string
-        ///   - maxHitsPerQuery: integer
-        ///   - queryParameters: string
-        ///   - maxQueriesPerIPPerHour: integer
-        /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
+        ///     can contains the following values:
+        ///     - acl: array of string
+        ///     - indices: array of string
+        ///     - validity: int
+        ///     - referers: array of string
+        ///     - description: string
+        ///     - maxHitsPerQuery: integer
+        ///     - queryParameters: string
+        ///     - maxQueriesPerIPPerHour: integer
+        ///     <returns>Returns an object with a "key" string attribute containing the new key.</returns>
+        /// <param name="requestOptions"></param>
+        /// <param name="token"></param>
         [Obsolete("UpdateUserKeyAsync is deprecated, please use UpdateApiKeyAsync instead.")]
-        public Task<JObject> UpdateUserKeyAsync(string key, Dictionary<string, object> parameters, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        public Task<JObject> UpdateUserKeyAsync(string key, Dictionary<string, object> parameters, RequestOptions requestOptions, CancellationToken token = default(CancellationToken))
         {
             return ExecuteRequest(callType.Write, "PUT", "/1/keys/" + key, parameters, token, requestOptions);
         }
@@ -775,17 +804,19 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="key">The user key</param>
         /// <param name="parameters">the list of parameters for this key. Defined by a Dictionnary that 
-        /// can contains the following values:
-        ///   - acl: array of string
-        ///   - indices: array of string
-        ///   - validity: int
-        ///   - referers: array of string
-        ///   - description: string
-        ///   - maxHitsPerQuery: integer
-        ///   - queryParameters: string
-        ///   - maxQueriesPerIPPerHour: integer
-        /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
-        public Task<JObject> UpdateApiKeyAsync(string key, Dictionary<string, object> parameters, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        ///     can contains the following values:
+        ///     - acl: array of string
+        ///     - indices: array of string
+        ///     - validity: int
+        ///     - referers: array of string
+        ///     - description: string
+        ///     - maxHitsPerQuery: integer
+        ///     - queryParameters: string
+        ///     - maxQueriesPerIPPerHour: integer
+        ///     <returns>Returns an object with a "key" string attribute containing the new key.</returns>
+        /// <param name="requestOptions"></param>
+        /// <param name="token"></param>
+        public Task<JObject> UpdateApiKeyAsync(string key, Dictionary<string, object> parameters, RequestOptions requestOptions, CancellationToken token = default(CancellationToken))
         {
             return ExecuteRequest(callType.Write, "PUT", "/1/keys/" + key, parameters, token, requestOptions);
         }
@@ -795,20 +826,21 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="key">The user key</param>
         /// <param name="parameters">the list of parameters for this key. Defined by a Dictionnary that 
-        /// can contains the following values:
-        ///   - acl: array of string
-        ///   - indices: array of string
-        ///   - validity: int
-        ///   - referers: array of string
-        ///   - description: string
-        ///   - maxHitsPerQuery: integer
-        ///   - queryParameters: string
-        ///   - maxQueriesPerIPPerHour: integer
-        /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
+        ///     can contains the following values:
+        ///     - acl: array of string
+        ///     - indices: array of string
+        ///     - validity: int
+        ///     - referers: array of string
+        ///     - description: string
+        ///     - maxHitsPerQuery: integer
+        ///     - queryParameters: string
+        ///     - maxQueriesPerIPPerHour: integer
+        ///     <returns>Returns an object with a "key" string attribute containing the new key.</returns>
+        /// <param name="requestOptions"></param>
         [Obsolete("UpdateUserKey is deprecated, please use UpdateApiKey instead.")]
-        public JObject UpdateUserKey(string key, Dictionary<string, object> parameters, RequestOptions requestOptions = null)
+        public JObject UpdateUserKey(string key, Dictionary<string, object> parameters, RequestOptions requestOptions)
         {
-            return UpdateApiKeyAsync(key, parameters, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return UpdateApiKeyAsync(key, parameters, requestOptions, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -816,19 +848,20 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="key">The user key</param>
         /// <param name="parameters">the list of parameters for this key. Defined by a Dictionnary that 
-        /// can contains the following values:
-        ///   - acl: array of string
-        ///   - indices: array of string
-        ///   - validity: int
-        ///   - referers: array of string
-        ///   - description: string
-        ///   - maxHitsPerQuery: integer
-        ///   - queryParameters: string
-        ///   - maxQueriesPerIPPerHour: integer
-        /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
-        public JObject UpdateApiKey(string key, Dictionary<string, object> parameters, RequestOptions requestOptions = null)
+        ///     can contains the following values:
+        ///     - acl: array of string
+        ///     - indices: array of string
+        ///     - validity: int
+        ///     - referers: array of string
+        ///     - description: string
+        ///     - maxHitsPerQuery: integer
+        ///     - queryParameters: string
+        ///     - maxQueriesPerIPPerHour: integer
+        ///     <returns>Returns an object with a "key" string attribute containing the new key.</returns>
+        /// <param name="requestOptions"></param>
+        public JObject UpdateApiKey(string key, Dictionary<string, object> parameters, RequestOptions requestOptions)
         {
-            return UpdateApiKeyAsync(key, parameters, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return UpdateApiKeyAsync(key, parameters, requestOptions, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -836,19 +869,20 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="key">The user key</param>
         /// <param name="acls">The list of ACL for this key. Defined by an array of strings that can contains the following values:
-        ///   - search: allow searching (https and http)
-        ///   - addObject: allow adding/updating an object in the index (https only)
-        ///   - deleteObject : allow deleting an existing object (https only)
-        ///   - deleteIndex : allow deleting an index (https only)
-        ///   - settings : allow getting index settings (https only)
-        ///   - editSettings : allow changing index settings (https only)</param>
+        ///     - search: allow searching (https and http)
+        ///     - addObject: allow adding/updating an object in the index (https only)
+        ///     - deleteObject : allow deleting an existing object (https only)
+        ///     - deleteIndex : allow deleting an index (https only)
+        ///     - settings : allow getting index settings (https only)
+        ///     - editSettings : allow changing index settings (https only)</param>
+        /// <param name="requestOptions"></param>
         /// <param name="validity">The number of seconds after which the key will be automatically removed (0 means no time limit for this key).</param>
         /// <param name="maxQueriesPerIPPerHour">Specify the maximum number of API calls allowed from an IP address per hour.  Defaults to 0 (no rate limit).</param>
         /// <param name="maxHitsPerQuery">Specify the maximum number of hits this API key can retrieve in one call. Defaults to 0 (unlimited).</param>
         /// <param name="indexes">Restrict the new API key to specific index names.</param>
         /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
         [Obsolete("UpdateUserKeyAsync is deprecated, please use UpdateApiKeyAsync instead.")]
-        public Task<JObject> UpdateUserKeyAsync(string key, IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, IEnumerable<string> indexes = null, RequestOptions requestOptions = null)
+        public Task<JObject> UpdateUserKeyAsync(string key, IEnumerable<string> acls, RequestOptions requestOptions, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, IEnumerable<string> indexes = null)
         {
             if (indexes == null)
             {
@@ -860,7 +894,7 @@ namespace Algolia.Search
             content["maxQueriesPerIPPerHour"] = maxQueriesPerIPPerHour;
             content["maxHitsPerQuery"] = maxHitsPerQuery;
             content["indexes"] = indexes;
-            return UpdateApiKeyAsync(key, content, default(CancellationToken), requestOptions);
+            return UpdateApiKeyAsync(key, content, requestOptions, default(CancellationToken));
         }
 
         /// <summary>
@@ -868,18 +902,19 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="key">The user key</param>
         /// <param name="acls">The list of ACL for this key. Defined by an array of strings that can contains the following values:
-        ///   - search: allow searching (https and http)
-        ///   - addObject: allow adding/updating an object in the index (https only)
-        ///   - deleteObject : allow deleting an existing object (https only)
-        ///   - deleteIndex : allow deleting an index (https only)
-        ///   - settings : allow getting index settings (https only)
-        ///   - editSettings : allow changing index settings (https only)</param>
+        ///     - search: allow searching (https and http)
+        ///     - addObject: allow adding/updating an object in the index (https only)
+        ///     - deleteObject : allow deleting an existing object (https only)
+        ///     - deleteIndex : allow deleting an index (https only)
+        ///     - settings : allow getting index settings (https only)
+        ///     - editSettings : allow changing index settings (https only)</param>
+        /// <param name="requestOptions"></param>
         /// <param name="validity">The number of seconds after which the key will be automatically removed (0 means no time limit for this key).</param>
         /// <param name="maxQueriesPerIPPerHour">Specify the maximum number of API calls allowed from an IP address per hour.  Defaults to 0 (no rate limit).</param>
         /// <param name="maxHitsPerQuery">Specify the maximum number of hits this API key can retrieve in one call. Defaults to 0 (unlimited).</param>
         /// <param name="indexes">Restrict the new API key to specific index names.</param>
         /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
-        public Task<JObject> UpdateApiKeyAsync(string key, IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, IEnumerable<string> indexes = null, RequestOptions requestOptions = null)
+        public Task<JObject> UpdateApiKeyAsync(string key, IEnumerable<string> acls, RequestOptions requestOptions, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, IEnumerable<string> indexes = null)
         {
             if (indexes == null)
             {
@@ -891,7 +926,7 @@ namespace Algolia.Search
             content["maxQueriesPerIPPerHour"] = maxQueriesPerIPPerHour;
             content["maxHitsPerQuery"] = maxHitsPerQuery;
             content["indexes"] = indexes;
-            return UpdateApiKeyAsync(key, content, default(CancellationToken), requestOptions);
+            return UpdateApiKeyAsync(key, content, requestOptions, default(CancellationToken));
         }
 
         /// <summary>
@@ -899,21 +934,22 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="key">The user key</param>
         /// <param name="acls">The list of ACL for this key. Defined by an array of strings that can contains the following values:
-        ///   - search: allow searching (https and http)
-        ///   - addObject: allow adding/updating an object in the index (https only)
-        ///   - deleteObject : allow deleting an existing object (https only)
-        ///   - deleteIndex : allow deleting an index (https only)
-        ///   - settings : allow getting index settings (https only)
-        ///   - editSettings : allow changing index settings (https only)</param>
+        ///     - search: allow searching (https and http)
+        ///     - addObject: allow adding/updating an object in the index (https only)
+        ///     - deleteObject : allow deleting an existing object (https only)
+        ///     - deleteIndex : allow deleting an index (https only)
+        ///     - settings : allow getting index settings (https only)
+        ///     - editSettings : allow changing index settings (https only)</param>
+        /// <param name="requestOptions"></param>
         /// <param name="validity">The number of seconds after which the key will be automatically removed (0 means no time limit for this key).</param>
         /// <param name="maxQueriesPerIPPerHour">Specify the maximum number of API calls allowed from an IP address per hour.  Defaults to 0 (no rate limit).</param>
         /// <param name="maxHitsPerQuery">Specify the maximum number of hits this API key can retrieve in one call. Defaults to 0 (unlimited).</param>
         /// <param name="indexes">Restrict the new API key to specific index names.</param>
         /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
         [Obsolete("UpdateUserKey is deprecated, please use UpdateApiKey instead.")]
-        public JObject UpdateUserKey(string key, IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, IEnumerable<string> indexes = null, RequestOptions requestOptions = null)
+        public JObject UpdateUserKey(string key, IEnumerable<string> acls, RequestOptions requestOptions, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, IEnumerable<string> indexes = null)
         {
-            return UpdateApiKeyAsync(key, acls, validity, maxQueriesPerIPPerHour, maxHitsPerQuery, indexes, requestOptions).GetAwaiter().GetResult();
+            return UpdateApiKeyAsync(key, acls, requestOptions, validity, maxQueriesPerIPPerHour, maxHitsPerQuery, indexes).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -921,28 +957,32 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="key">The user key</param>
         /// <param name="acls">The list of ACL for this key. Defined by an array of strings that can contains the following values:
-        ///   - search: allow searching (https and http)
-        ///   - addObject: allow adding/updating an object in the index (https only)
-        ///   - deleteObject : allow deleting an existing object (https only)
-        ///   - deleteIndex : allow deleting an index (https only)
-        ///   - settings : allow getting index settings (https only)
-        ///   - editSettings : allow changing index settings (https only)</param>
+        ///     - search: allow searching (https and http)
+        ///     - addObject: allow adding/updating an object in the index (https only)
+        ///     - deleteObject : allow deleting an existing object (https only)
+        ///     - deleteIndex : allow deleting an index (https only)
+        ///     - settings : allow getting index settings (https only)
+        ///     - editSettings : allow changing index settings (https only)</param>
+        /// <param name="requestOptions"></param>
         /// <param name="validity">The number of seconds after which the key will be automatically removed (0 means no time limit for this key).</param>
         /// <param name="maxQueriesPerIPPerHour">Specify the maximum number of API calls allowed from an IP address per hour.  Defaults to 0 (no rate limit).</param>
         /// <param name="maxHitsPerQuery">Specify the maximum number of hits this API key can retrieve in one call. Defaults to 0 (unlimited).</param>
         /// <param name="indexes">Restrict the new API key to specific index names.</param>
         /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
-        public JObject UpdateApiKey(string key, IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, IEnumerable<string> indexes = null, RequestOptions requestOptions = null)
+        public JObject UpdateApiKey(string key, IEnumerable<string> acls, RequestOptions requestOptions, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, IEnumerable<string> indexes = null)
         {
-            return UpdateApiKeyAsync(key, acls, validity, maxQueriesPerIPPerHour, maxHitsPerQuery, indexes, requestOptions).GetAwaiter().GetResult();
+            return UpdateApiKeyAsync(key, acls, requestOptions, validity, maxQueriesPerIPPerHour, maxHitsPerQuery, indexes).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Send a batch targeting multiple indices
         /// </summary>
+        /// <param name="requests"></param>
+        /// <param name="requestOptions"></param>
+        /// <param name="token"></param>
         /// <param name="actions">An array of action to send.</param>
         /// <returns>An object containing an "objectIDs" attribute (array of string) and a dictionary for the taskIDs.</returns>
-        public Task<JObject> BatchAsync(IEnumerable<object> requests, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        public Task<JObject> BatchAsync(IEnumerable<object> requests, RequestOptions requestOptions, CancellationToken token = default(CancellationToken))
         {
             Dictionary<string, object> batch = new Dictionary<string, object>();
             batch["requests"] = requests;
@@ -952,11 +992,13 @@ namespace Algolia.Search
         /// <summary>
         /// Synchronously call <see cref="AlgoliaClient.BatchAsync"/>
         /// </summary>
+        /// <param name="requests"></param>
+        /// <param name="requestOptions"></param>
         /// <param name="actions">An array of action to send.</param>
         /// <returns>An object containing an "objectIDs" attribute (array of string) and a dictionary for the taskIDs.</returns>
-        public JObject Batch(IEnumerable<object> requests, RequestOptions requestOptions = null)
+        public JObject Batch(IEnumerable<object> requests, RequestOptions requestOptions)
         {
-            return BatchAsync(requests, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return BatchAsync(requests, requestOptions, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
 
@@ -1078,7 +1120,7 @@ namespace Algolia.Search
         /// <param name="content">The content</param>
         /// <param name="requestOptions">The additional request options</param>
         /// <returns></returns>
-        public async Task<JObject> ExecuteRequest(callType type, string method, string requestUrl, object content, CancellationToken token, RequestOptions requestOptions = null)
+        public async Task<JObject> ExecuteRequest(callType type, string method, string requestUrl, object content, CancellationToken token, RequestOptions requestOptions)
         {
             string[] hosts = null;
             string requestExtraQueryParams = "";
@@ -1267,5 +1309,523 @@ namespace Algolia.Search
 
             return stringBuilder;
         }
+
+        /* 
+         * These are overloaded methods of everything above in order to avoid binary incompatibility 
+         * when adding all the requestOptions parameters
+         */
+
+        /// <summary>
+        /// This method allows querying multiple indexes with one API call
+        /// </summary>
+        /// <param name="queries">List of queries per index</param>
+        /// <param name="strategy">Strategy applied on the sequence of queries</param>
+        /// <returns></returns>
+        public Task<JObject> MultipleQueriesAsync(List<IndexQuery> queries, string strategy = "none", CancellationToken token = default(CancellationToken))
+        { return MultipleQueriesAsync(queries, null, strategy, token); }
+
+        /// <summary>
+        /// Synchronously call <see cref="AlgoliaClient.MultipleQueriesAsync"/>
+        /// </summary>
+        /// <param name="queries">List of queries per index</param>
+        /// <returns></returns>
+        public JObject MultipleQueries(List<IndexQuery> queries, string strategy = "none", CancellationToken token = default(CancellationToken))
+        { return MultipleQueries(queries, null, strategy, token); }
+        /// </returns>
+        public Task<JObject> ListIndexesAsync(CancellationToken token = default(CancellationToken))
+        { return ListIndexesAsync(null, token); }
+        /// </returns>
+        public JObject ListIndexes()
+        {
+            return ListIndexes(null);
+        }
+
+        /// <summary>
+        /// Delete an index.
+        /// </summary>
+        /// <param name="indexName">The name of index to delete</param>
+        /// <returns>An object containing a "deletedAt" attribute</returns>
+        public Task<JObject> DeleteIndexAsync(string indexName, CancellationToken token = default(CancellationToken))
+        { return DeleteIndexAsync(indexName, null, token); }
+
+        /// <summary>
+        /// Synchronously call <see cref="AlgoliaClient.DeleteIndexAsync"/> 
+        /// </summary>
+        /// <returns>An object containing a "deletedAt" attribute</returns>
+        public JObject DeleteIndex(string indexName)
+        { return DeleteIndex(indexName, null); }
+
+        /// <summary>
+        /// Move an existing index.
+        /// </summary>
+        /// <param name="srcIndexName">The name of index to move.</param>
+        /// <param name="dstIndexName">The new index name that will contain a copy of srcIndexName (destination will be overriten if it already exists).</param>
+        public Task<JObject> MoveIndexAsync(string srcIndexName, string dstIndexName, CancellationToken token = default(CancellationToken))
+        { return MoveIndexAsync(srcIndexName, dstIndexName, null, token); }
+        /// <summary>
+        /// Synchronously call <see cref="AlgoliaClient.MoveIndexAsync"/>
+        /// </summary>
+        /// <param name="srcIndexName">The name of index to move.</param>
+        /// <param name="dstIndexName">The new index name that will contain a copy of srcIndexName (destination will be overriten if it already exists).</param>
+        public JObject MoveIndex(string srcIndexName, string dstIndexName)
+        { return MoveIndex(srcIndexName, dstIndexName, null); }
+
+        /// <summary>
+        /// Copy an existing index.
+        /// </summary>
+        /// <param name="srcIndexName">The name of index to copy.</param>
+        /// <param name="dstIndexName">The new index name that will contain a copy of srcIndexName (destination will be overriten if it already exists).</param>
+        public Task<JObject> CopyIndexAsync(string srcIndexName, string dstIndexName, CancellationToken token = default(CancellationToken))
+        { return CopyIndexAsync(srcIndexName, dstIndexName, null, token); }
+        /// <summary>
+        /// Synchronously call <see cref="AlgoliaClient.CopyIndexAsync"/> 
+        /// </summary>
+        /// <param name="srcIndexName">The name of index to copy.</param>
+        /// <param name="dstIndexName">The new index name that will contain a copy of srcIndexName (destination will be overriten if it already exists).</param>
+        public JObject CopyIndex(string srcIndexName, string dstIndexName)
+        { return CopyIndex(srcIndexName, dstIndexName, null); }
+
+        /// <summary>
+        /// Return last logs entries.
+        /// </summary>
+        /// <param name="offset">Specify the first entry to retrieve (0-based, 0 is the most recent log entry).</param>
+        /// <param name="length">Specify the maximum number of entries to retrieve starting at offset. Maximum allowed value: 1000.</param>
+        /// <param name="onlyErrors">If set to true, the answer will only contain API calls with errors.</param>
+        public Task<JObject> GetLogsAsync(int offset = 0, int length = 10, bool onlyErrors = false)
+        { return GetLogsAsync(null, offset, length, onlyErrors); }
+
+        /// <summary>
+        /// Return last logs entries.
+        /// </summary>
+        /// <param name="offset">Specify the first entry to retrieve (0-based, 0 is the most recent log entry).</param>
+        /// <param name="length">Specify the maximum number of entries to retrieve starting at offset. Maximum allowed value: 1000.</param>
+        /// <param name="logType">Specify the type of logs to include.</param>
+        public Task<JObject> GetLogsAsync(int offset = 0, int length = 10, LogType logType = LogType.LOG_ALL, CancellationToken token = default(CancellationToken))
+        { return GetLogsAsync(null, offset, length, logType, token); }
+
+        /// <summary>
+        /// Synchronously call <see cref="AlgoliaClient.GetLogsAsync(int, int, bool)"/>
+        /// </summary>
+        /// <param name="offset">Specify the first entry to retrieve (0-based, 0 is the most recent log entry).</param>
+        /// <param name="length">Specify the maximum number of entries to retrieve starting at offset. Maximum allowed value: 1000.</param>
+        /// <param name="onlyErrors">If set to true, the answer will only contain API calls with errors.</param>
+        public JObject GetLogs(int offset = 0, int length = 10, bool onlyErrors = false)
+        { return GetLogs(null, offset, length, onlyErrors); }
+
+        /// <summary>
+        /// Synchronously call <see cref="AlgoliaClient.GetLogsAsync(int, int, Algolia.Search.AlgoliaClient.LogType)"/>
+        /// </summary>
+        /// <param name="offset">Specify the first entry to retrieve (0-based, 0 is the most recent log entry).</param>
+        /// <param name="length">Specify the maximum number of entries to retrieve starting at offset. Maximum allowed value: 1000.</param>
+        /// <param name="logType">Specify the type of logs to include.</param>
+        public JObject GetLogs(int offset, int length, LogType logType)
+        { return GetLogs(offset, length, logType, null); }
+
+        /// <summary>
+        /// List all existing user keys with their associated ACLs.
+        /// </summary>
+        /// <returns>An object containing the list of keys.</returns>
+        [Obsolete("ListUserKeysAsync is deprecated, please use ListApiKeysAsync instead.")]
+        public Task<JObject> ListUserKeysAsync(CancellationToken token = default(CancellationToken))
+        { return ListUserKeysAsync(null, token); }
+
+        /// <summary>
+        /// List all existing api keys with their associated ACLs.
+        /// </summary>
+        /// <returns>An object containing the list of keys.</returns>
+        public Task<JObject> ListApiKeysAsync(CancellationToken token = default(CancellationToken))
+        { return ListApiKeysAsync(null, token); }
+
+        /// <summary>
+        /// Synchronously call <see cref="AlgoliaClient.ListApiKeysAsync"/> 
+        /// </summary>
+        /// <returns>An object containing the list of keys.</returns>
+        [Obsolete("ListUserKeys is deprecated, please use ListApiKeys instead.")]
+        public JObject ListUserKeys()
+        {
+            return ListUserKeys(null);
+        }
+
+        /// <summary>
+        /// Synchronously call <see cref="AlgoliaClient.ListApiKeysAsync"/> 
+        /// </summary>
+        /// <returns>An object containing the list of keys.</returns>
+        public JObject ListApiKeys()
+        {
+            return ListApiKeys(null);
+        }
+
+        /// <summary>
+        /// Get ACL for an existing user key.
+        /// </summary>
+        /// <returns>Returns an object with an "acls" array containing an array of strings with rights.</returns>
+        [Obsolete("GetUserKeyACLAsync is deprecated, please use GetApiKeyACLAsync instead.")]
+        public Task<JObject> GetUserKeyACLAsync(string key, CancellationToken token = default(CancellationToken))
+        { return GetUserKeyACLAsync(key, null, token); }
+
+        /// <summary>
+        /// Get ACL for an existing api key.
+        /// </summary>
+        /// <returns>Returns an object with an "acls" array containing an array of strings with rights.</returns>
+        public Task<JObject> GetApiKeyACLAsync(string key, CancellationToken token = default(CancellationToken))
+        { return GetApiKeyACLAsync(key, null, token); }
+
+        /// <summary>
+        /// Synchronously call <see cref="AlgoliaClient.GetApiKeyACLAsync"/> 
+        /// </summary>
+        /// <returns>Returns an object with an "acls" array containing an array of strings with rights.</returns>
+        [Obsolete("GetUserKeyACL is deprecated, please use GetApiKeyACL instead.")]
+        public JObject GetUserKeyACL(string key)
+        { return GetUserKeyACL(key, null); }
+
+        /// <summary>
+        /// Synchronously call <see cref="AlgoliaClient.GetApiKeyACLAsync"/> 
+        /// </summary>
+        /// <returns>Returns an object with an "acls" array containing an array of strings with rights.</returns>
+        public JObject GetApiKeyACL(string key)
+        { return GetApiKeyACL(key, null); }
+
+        /// <summary>
+        /// Delete an existing user key.
+        /// </summary>
+        /// <returns>Returns an object with a "deleteAt" attribute.</returns>
+        [Obsolete("DeleteUserKeyAsync is deprecated, please use DeleteApiKeyAsync instead.")]
+        public Task<JObject> DeleteUserKeyAsync(string key, CancellationToken token = default(CancellationToken))
+        { return DeleteUserKeyAsync(key, null, token); }
+
+        /// <summary>
+        /// Delete an existing user key.
+        /// </summary>
+        /// <returns>Returns an object with a "deleteAt" attribute.</returns>
+        public Task<JObject> DeleteApiKeyAsync(string key, CancellationToken token = default(CancellationToken))
+        { return DeleteApiKeyAsync(key, null, token); }
+
+        /// <summary>
+        /// Synchronously call <see cref="AlgoliaClient.DeleteApiKeyAsync"/> 
+        /// </summary>
+        /// <returns>Returns an object with a "deleteAt" attribute.</returns>
+        [Obsolete("DeleteUserKey is deprecated, please use DeleteApiKey instead.")]
+        public JObject DeleteUserKey(string key)
+        { return DeleteUserKey(key, null); }
+
+        /// <summary>
+        /// Synchronously call <see cref="AlgoliaClient.DeleteApiKeyAsync"/> 
+        /// </summary>
+        /// <returns>Returns an object with a "deleteAt" attribute.</returns>
+        public JObject DeleteApiKey(string key)
+        { return DeleteApiKey(key, null); }
+
+        /// <summary>
+        /// Create a new user key.
+        /// </summary>
+        /// <param name="parameters">the list of parameters for this key. Defined by a Dictionnary that 
+        /// can contains the following values:
+        ///   - acl: array of string
+        ///   - indices: array of string
+        ///   - validity: int
+        ///   - referers: array of string
+        ///   - description: string
+        ///   - maxHitsPerQuery: integer
+        ///   - queryParameters: string
+        ///   - maxQueriesPerIPPerHour: integer
+        /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
+        [Obsolete("AddUserKeyAsync is deprecated, please use AddApiKeyAsync instead.")]
+        public Task<JObject> AddUserKeyAsync(Dictionary<string, object> parameters, CancellationToken token = default(CancellationToken))
+        { return AddUserKeyAsync(parameters, null, token); }
+
+        /// <summary>
+        /// Create a new api key.
+        /// </summary>
+        /// <param name="parameters">the list of parameters for this key. Defined by a Dictionnary that 
+        /// can contains the following values:
+        ///   - acl: array of string
+        ///   - indices: array of string
+        ///   - validity: int
+        ///   - referers: array of string
+        ///   - description: string
+        ///   - maxHitsPerQuery: integer
+        ///   - queryParameters: string
+        ///   - maxQueriesPerIPPerHour: integer
+        /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
+        public Task<JObject> AddApiKeyAsync(Dictionary<string, object> parameters, CancellationToken token = default(CancellationToken))
+        { return AddApiKeyAsync(parameters, null, token); }
+
+        /// <summary>
+        /// Synchronously call <see cref="AlgoliaClient.AddApiKeyAsync"/>
+        /// </summary>
+        /// <param name="parameters">the list of parameters for this key. Defined by a Dictionnary that 
+        /// can contains the following values:
+        ///   - acl: array of string
+        ///   - indices: array of string
+        ///   - validity: int
+        ///   - referers: array of string
+        ///   - description: string
+        ///   - maxHitsPerQuery: integer
+        ///   - queryParameters: string
+        ///   - maxQueriesPerIPPerHour: integer
+        /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
+        [Obsolete("AddUserKey is deprecated, please use AddApiKey instead.")]
+        public JObject AddUserKey(Dictionary<string, object> parameters)
+        { return AddUserKey(parameters, null); }
+
+        /// <summary>
+        /// Synchronously call <see cref="AlgoliaClient.AddApiKeyAsync"/>
+        /// </summary>
+        /// <param name="parameters">the list of parameters for this key. Defined by a Dictionnary that 
+        /// can contains the following values:
+        ///   - acl: array of string
+        ///   - indices: array of string
+        ///   - validity: int
+        ///   - referers: array of string
+        ///   - description: string
+        ///   - maxHitsPerQuery: integer
+        ///   - queryParameters: string
+        ///   - maxQueriesPerIPPerHour: integer
+        /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
+        public JObject AddApiKey(Dictionary<string, object> parameters)
+        { return AddApiKey(parameters, null); }
+
+        /// <summary>
+        /// Create a new user key.
+        /// </summary>
+        /// <param name="acls">The list of ACL for this key. Defined by an array of strings that can contains the following values:
+        ///   - search: allow searching (https and http)
+        ///   - addObject: allow adding/updating an object in the index (https only)
+        ///   - deleteObject : allow deleting an existing object (https only)
+        ///   - deleteIndex : allow deleting an index (https only)
+        ///   - settings : allow getting index settings (https only)
+        ///   - editSettings : allow changing index settings (https only)</param>
+        /// <param name="validity">The number of seconds after which the key will be automatically removed (0 means no time limit for this key).</param>
+        /// <param name="maxQueriesPerIPPerHour">Specify the maximum number of API calls allowed from an IP address per hour.  Defaults to 0 (no rate limit).</param>
+        /// <param name="maxHitsPerQuery">Specify the maximum number of hits this API key can retrieve in one call. Defaults to 0 (unlimited).</param>
+        /// <param name="indexes">Restrict the new API key to specific index names.</param>
+        /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
+        [Obsolete("AddUserKeyAsync is deprecated, please use AddApiKeyAsync instead.")]
+        public Task<JObject> AddUserKeyAsync(IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, IEnumerable<string> indexes = null)
+        { return AddUserKeyAsync(acls, null, validity, maxQueriesPerIPPerHour, maxHitsPerQuery, indexes); }
+
+        /// <summary>
+        /// Create a new api key.
+        /// </summary>
+        /// <param name="acls">The list of ACL for this key. Defined by an array of strings that can contains the following values:
+        ///   - search: allow searching (https and http)
+        ///   - addObject: allow adding/updating an object in the index (https only)
+        ///   - deleteObject : allow deleting an existing object (https only)
+        ///   - deleteIndex : allow deleting an index (https only)
+        ///   - settings : allow getting index settings (https only)
+        ///   - editSettings : allow changing index settings (https only)</param>
+        /// <param name="validity">The number of seconds after which the key will be automatically removed (0 means no time limit for this key).</param>
+        /// <param name="maxQueriesPerIPPerHour">Specify the maximum number of API calls allowed from an IP address per hour.  Defaults to 0 (no rate limit).</param>
+        /// <param name="maxHitsPerQuery">Specify the maximum number of hits this API key can retrieve in one call. Defaults to 0 (unlimited).</param>
+        /// <param name="indexes">Restrict the new API key to specific index names.</param>
+        /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
+        public Task<JObject> AddApiKeyAsync(IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, IEnumerable<string> indexes = null)
+        { return AddApiKeyAsync(acls, null, validity, maxQueriesPerIPPerHour, maxHitsPerQuery, indexes); }
+
+        /// <summary>
+        /// Synchronously call <see cref="AlgoliaClient.AddApiKeyAsync"/>
+        /// </summary>
+        /// <param name="acls">The list of ACL for this key. Defined by an array of strings that can contains the following values:
+        ///   - search: allow searching (https and http)
+        ///   - addObject: allow adding/updating an object in the index (https only)
+        ///   - deleteObject : allow deleting an existing object (https only)
+        ///   - deleteIndex : allow deleting an index (https only)
+        ///   - settings : allow getting index settings (https only)
+        ///   - editSettings : allow changing index settings (https only)</param>
+        /// <param name="validity">The number of seconds after which the key will be automatically removed (0 means no time limit for this key).</param>
+        /// <param name="maxQueriesPerIPPerHour">Specify the maximum number of API calls allowed from an IP address per hour.  Defaults to 0 (no rate limit).</param>
+        /// <param name="maxHitsPerQuery">Specify the maximum number of hits this API key can retrieve in one call. Defaults to 0 (unlimited).</param>
+        /// <param name="indexes">Restrict the new API key to specific index names.</param>
+        /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
+        [Obsolete("AddUserKey is deprecated, please use AddApiKey instead.")]
+        public JObject AddUserKey(IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, IEnumerable<string> indexes = null)
+        { return AddUserKey(acls, null, validity, maxQueriesPerIPPerHour, maxHitsPerQuery, indexes); }
+
+        /// <summary>
+        /// Synchronously call <see cref="AlgoliaClient.AddApiKeyAsync"/>
+        /// </summary>
+        /// <param name="acls">The list of ACL for this key. Defined by an array of strings that can contains the following values:
+        ///   - search: allow searching (https and http)
+        ///   - addObject: allow adding/updating an object in the index (https only)
+        ///   - deleteObject : allow deleting an existing object (https only)
+        ///   - deleteIndex : allow deleting an index (https only)
+        ///   - settings : allow getting index settings (https only)
+        ///   - editSettings : allow changing index settings (https only)</param>
+        /// <param name="validity">The number of seconds after which the key will be automatically removed (0 means no time limit for this key).</param>
+        /// <param name="maxQueriesPerIPPerHour">Specify the maximum number of API calls allowed from an IP address per hour.  Defaults to 0 (no rate limit).</param>
+        /// <param name="maxHitsPerQuery">Specify the maximum number of hits this API key can retrieve in one call. Defaults to 0 (unlimited).</param>
+        /// <param name="indexes">Restrict the new API key to specific index names.</param>
+        /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
+        public JObject AddApiKey(IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, IEnumerable<string> indexes = null)
+        { return AddApiKey(acls, null, validity, maxQueriesPerIPPerHour, maxHitsPerQuery, indexes); }
+
+        /// <summary>
+        /// Update a user key.
+        /// </summary>
+        /// <param name="key">The user key</param>
+        /// <param name="parameters">the list of parameters for this key. Defined by a Dictionnary that 
+        /// can contains the following values:
+        ///   - acl: array of string
+        ///   - indices: array of string
+        ///   - validity: int
+        ///   - referers: array of string
+        ///   - description: string
+        ///   - maxHitsPerQuery: integer
+        ///   - queryParameters: string
+        ///   - maxQueriesPerIPPerHour: integer
+        /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
+        [Obsolete("UpdateUserKeyAsync is deprecated, please use UpdateApiKeyAsync instead.")]
+        public Task<JObject> UpdateUserKeyAsync(string key, Dictionary<string, object> parameters, CancellationToken token = default(CancellationToken))
+        { return UpdateUserKeyAsync(key, parameters, null, token); }
+
+        /// <summary>
+        /// Update an api key.
+        /// </summary>
+        /// <param name="key">The user key</param>
+        /// <param name="parameters">the list of parameters for this key. Defined by a Dictionnary that 
+        /// can contains the following values:
+        ///   - acl: array of string
+        ///   - indices: array of string
+        ///   - validity: int
+        ///   - referers: array of string
+        ///   - description: string
+        ///   - maxHitsPerQuery: integer
+        ///   - queryParameters: string
+        ///   - maxQueriesPerIPPerHour: integer
+        /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
+        public Task<JObject> UpdateApiKeyAsync(string key, Dictionary<string, object> parameters, CancellationToken token = default(CancellationToken))
+        { return UpdateApiKeyAsync(key, parameters, null, token); }
+
+        /// <summary>
+        /// Synchronously call <see cref="AlgoliaClient.UpdateApiKeyAsync"/>
+        /// </summary>
+        /// <param name="key">The user key</param>
+        /// <param name="parameters">the list of parameters for this key. Defined by a Dictionnary that 
+        /// can contains the following values:
+        ///   - acl: array of string
+        ///   - indices: array of string
+        ///   - validity: int
+        ///   - referers: array of string
+        ///   - description: string
+        ///   - maxHitsPerQuery: integer
+        ///   - queryParameters: string
+        ///   - maxQueriesPerIPPerHour: integer
+        /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
+        [Obsolete("UpdateUserKey is deprecated, please use UpdateApiKey instead.")]
+        public JObject UpdateUserKey(string key, Dictionary<string, object> parameters)
+        { return UpdateUserKey(key, parameters, null); }
+
+        /// <summary>
+        /// Synchronously call <see cref="AlgoliaClient.UpdateApiKeyAsync"/>
+        /// </summary>
+        /// <param name="key">The user key</param>
+        /// <param name="parameters">the list of parameters for this key. Defined by a Dictionnary that 
+        /// can contains the following values:
+        ///   - acl: array of string
+        ///   - indices: array of string
+        ///   - validity: int
+        ///   - referers: array of string
+        ///   - description: string
+        ///   - maxHitsPerQuery: integer
+        ///   - queryParameters: string
+        ///   - maxQueriesPerIPPerHour: integer
+        /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
+        public JObject UpdateApiKey(string key, Dictionary<string, object> parameters)
+        { return UpdateApiKey(key, parameters, null); }
+
+        /// <summary>
+        /// Update a user key.
+        /// </summary>
+        /// <param name="key">The user key</param>
+        /// <param name="acls">The list of ACL for this key. Defined by an array of strings that can contains the following values:
+        ///   - search: allow searching (https and http)
+        ///   - addObject: allow adding/updating an object in the index (https only)
+        ///   - deleteObject : allow deleting an existing object (https only)
+        ///   - deleteIndex : allow deleting an index (https only)
+        ///   - settings : allow getting index settings (https only)
+        ///   - editSettings : allow changing index settings (https only)</param>
+        /// <param name="validity">The number of seconds after which the key will be automatically removed (0 means no time limit for this key).</param>
+        /// <param name="maxQueriesPerIPPerHour">Specify the maximum number of API calls allowed from an IP address per hour.  Defaults to 0 (no rate limit).</param>
+        /// <param name="maxHitsPerQuery">Specify the maximum number of hits this API key can retrieve in one call. Defaults to 0 (unlimited).</param>
+        /// <param name="indexes">Restrict the new API key to specific index names.</param>
+        /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
+        [Obsolete("UpdateUserKeyAsync is deprecated, please use UpdateApiKeyAsync instead.")]
+        public Task<JObject> UpdateUserKeyAsync(string key, IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, IEnumerable<string> indexes = null)
+        { return UpdateUserKeyAsync(key, acls, null, validity, maxQueriesPerIPPerHour, maxHitsPerQuery, indexes); }
+
+        /// <summary>
+        /// Update an api key.
+        /// </summary>
+        /// <param name="key">The user key</param>
+        /// <param name="acls">The list of ACL for this key. Defined by an array of strings that can contains the following values:
+        ///   - search: allow searching (https and http)
+        ///   - addObject: allow adding/updating an object in the index (https only)
+        ///   - deleteObject : allow deleting an existing object (https only)
+        ///   - deleteIndex : allow deleting an index (https only)
+        ///   - settings : allow getting index settings (https only)
+        ///   - editSettings : allow changing index settings (https only)</param>
+        /// <param name="validity">The number of seconds after which the key will be automatically removed (0 means no time limit for this key).</param>
+        /// <param name="maxQueriesPerIPPerHour">Specify the maximum number of API calls allowed from an IP address per hour.  Defaults to 0 (no rate limit).</param>
+        /// <param name="maxHitsPerQuery">Specify the maximum number of hits this API key can retrieve in one call. Defaults to 0 (unlimited).</param>
+        /// <param name="indexes">Restrict the new API key to specific index names.</param>
+        /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
+        public Task<JObject> UpdateApiKeyAsync(string key, IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, IEnumerable<string> indexes = null)
+        { return UpdateApiKeyAsync(key, acls, null, validity, maxQueriesPerIPPerHour, maxHitsPerQuery, indexes); }
+
+        /// <summary>
+        /// Synchronously call <see cref="AlgoliaClient.UpdateApiKeyAsync"/>
+        /// </summary>
+        /// <param name="key">The user key</param>
+        /// <param name="acls">The list of ACL for this key. Defined by an array of strings that can contains the following values:
+        ///   - search: allow searching (https and http)
+        ///   - addObject: allow adding/updating an object in the index (https only)
+        ///   - deleteObject : allow deleting an existing object (https only)
+        ///   - deleteIndex : allow deleting an index (https only)
+        ///   - settings : allow getting index settings (https only)
+        ///   - editSettings : allow changing index settings (https only)</param>
+        /// <param name="validity">The number of seconds after which the key will be automatically removed (0 means no time limit for this key).</param>
+        /// <param name="maxQueriesPerIPPerHour">Specify the maximum number of API calls allowed from an IP address per hour.  Defaults to 0 (no rate limit).</param>
+        /// <param name="maxHitsPerQuery">Specify the maximum number of hits this API key can retrieve in one call. Defaults to 0 (unlimited).</param>
+        /// <param name="indexes">Restrict the new API key to specific index names.</param>
+        /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
+        [Obsolete("UpdateUserKey is deprecated, please use UpdateApiKey instead.")]
+        public JObject UpdateUserKey(string key, IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, IEnumerable<string> indexes = null)
+        { return UpdateUserKey(key, acls, null, validity, maxQueriesPerIPPerHour, maxHitsPerQuery, indexes); }
+
+        /// <summary>
+        /// Synchronously call <see cref="AlgoliaClient.UpdateApiKeyAsync"/>
+        /// </summary>
+        /// <param name="key">The user key</param>
+        /// <param name="acls">The list of ACL for this key. Defined by an array of strings that can contains the following values:
+        ///   - search: allow searching (https and http)
+        ///   - addObject: allow adding/updating an object in the index (https only)
+        ///   - deleteObject : allow deleting an existing object (https only)
+        ///   - deleteIndex : allow deleting an index (https only)
+        ///   - settings : allow getting index settings (https only)
+        ///   - editSettings : allow changing index settings (https only)</param>
+        /// <param name="validity">The number of seconds after which the key will be automatically removed (0 means no time limit for this key).</param>
+        /// <param name="maxQueriesPerIPPerHour">Specify the maximum number of API calls allowed from an IP address per hour.  Defaults to 0 (no rate limit).</param>
+        /// <param name="maxHitsPerQuery">Specify the maximum number of hits this API key can retrieve in one call. Defaults to 0 (unlimited).</param>
+        /// <param name="indexes">Restrict the new API key to specific index names.</param>
+        /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
+        public JObject UpdateApiKey(string key, IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, IEnumerable<string> indexes = null)
+        { return UpdateApiKey(key, acls, null, validity, maxQueriesPerIPPerHour, maxHitsPerQuery, indexes); }
+
+        /// <summary>
+        /// Send a batch targeting multiple indices
+        /// </summary>
+        /// <param name="actions">An array of action to send.</param>
+        /// <returns>An object containing an "objectIDs" attribute (array of string) and a dictionary for the taskIDs.</returns>
+        public Task<JObject> BatchAsync(IEnumerable<object> requests, CancellationToken token = default(CancellationToken))
+        { return BatchAsync(requests, null, token); }
+
+        /// <summary>
+        /// Synchronously call <see cref="AlgoliaClient.BatchAsync"/>
+        /// </summary>
+        /// <param name="actions">An array of action to send.</param>
+        /// <returns>An object containing an "objectIDs" attribute (array of string) and a dictionary for the taskIDs.</returns>
+        public JObject Batch(IEnumerable<object> requests)
+        { return Batch(requests, null); }
+
     }
 }

--- a/Algolia.Search/Index.cs
+++ b/Algolia.Search/Index.cs
@@ -1480,5 +1480,137 @@ namespace Algolia.Search
             body["params"] = paramsString;
             return _client.ExecuteRequest(AlgoliaClient.callType.Read, "POST", string.Format("/1/indexes/{0}/facets/{1}/query", _urlIndexName, facetName), body, token, requestOptions);
         }
+
+        /// <summary>
+        ///  Save a new rule in the index.
+        /// </summary>
+        /// <param name="queryRule">The body of the rule to save (must contain an objectID attribute).</param>
+        /// <param name="forwardToReplicas">whether to forward to replicas or not (defaults to false)</param>
+        public Task<JObject> SaveRuleAsync(JObject queryRule, bool forwardToReplicas = false, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        {
+            if (queryRule["objectID"] == null)
+            {
+                throw new AlgoliaException("objectID is missing");
+            }
+
+            string objectID = (string)queryRule["objectID"];
+            return _client.ExecuteRequest(AlgoliaClient.callType.Write, "PUT", string.Format("/1/indexes/{0}/rules/{1}?forwardToReplicas={2}", _urlIndexName, WebUtility.UrlEncode(objectID), forwardToReplicas.ToString().ToLower()), queryRule, token, requestOptions);
+        }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.SaveRuleAsync"/>.
+        /// </summary>
+        /// <param name="queryRule">The object to save (must contain an objectID attribute).</param>
+        /// <param name="forwardToReplicas">whether to forward to replicas or not (defaults to false)</param>
+        public JObject SaveRule(JObject queryRule, bool forwardToReplicas = false, RequestOptions requestOptions = null)
+        {
+            return SaveRuleAsync(queryRule,forwardToReplicas,default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        ///  Retrieve a rule from the index with the specified objectID.
+        /// </summary>
+        /// <param name="objectID">The objectID of the rule to retrieve.</param>
+        public Task<JObject> GetRuleAsync(string objectID, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        {
+            if (string.IsNullOrEmpty(objectID))
+            {
+                throw new AlgoliaException("objectID is missing");
+            }
+
+            return _client.ExecuteRequest(AlgoliaClient.callType.Read, "GET", string.Format("/1/indexes/{0}/rules/{1}", _urlIndexName, WebUtility.UrlEncode(objectID)), null, token, requestOptions);
+        }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.GetRuleAsync"/>.
+        /// </summary>
+        /// <param name="objectID">The objectID of the rule to retrieve.</param>
+        public JObject GetRule(string objectID, RequestOptions requestOptions = null)
+        {
+            return GetRuleAsync(objectID, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        ///  Search for rules inside the index.
+        /// </summary>
+        /// <param name="query">the query rules</param>
+        public Task<JObject> SearchRulesAsync(RuleQuery query = null, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        {
+            return _client.ExecuteRequest(AlgoliaClient.callType.Write, "POST", string.Format("/1/indexes/{0}/rules/search", _urlIndexName), query, token, requestOptions);
+        }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.SearchRulesAsync"/>.
+        /// </summary>
+        /// <param name="query">the query rules</param>
+        public JObject SearchRules(RuleQuery query = null, RequestOptions requestOptions = null)
+        {
+	        return SearchRulesAsync(query, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        ///  Delete a rule from the index with the specified objectID.
+        /// </summary>
+        /// <param name="objectID">The objectID of the rule to retrieve.</param>
+        /// <param name="forwardToReplicas">whether to forward to replicas or not (defaults to false)</param>
+        public Task<JObject> DeleteRuleAsync(string objectID, bool forwardToReplicas = false, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        {
+            if (string.IsNullOrEmpty(objectID))
+            {
+                throw new AlgoliaException("objectID is missing");
+            }
+
+            return _client.ExecuteRequest(AlgoliaClient.callType.Write, "DELETE", string.Format("/1/indexes/{0}/rules/{1}?forwardToReplicas={2}", _urlIndexName, WebUtility.UrlEncode(objectID), forwardToReplicas.ToString().ToLower()), null, token, requestOptions);
+        }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.DeleteRuleAsync"/>.
+        /// </summary>
+        /// <param name="objectID">The objectID of the rule to retrieve.</param>
+        /// <param name="forwardToReplicas">whether to forward to replicas or not (defaults to false)</param>
+        public JObject DeleteRule(string objectID, bool forwardToReplicas = false, RequestOptions requestOptions = null)
+        {
+            return DeleteRuleAsync(objectID, forwardToReplicas, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Clear all the rules of an index.
+        /// </summary>
+        /// <param name="forwardToReplicas">whether to forward to replicas or not (defaults to false)</param>
+        public Task<JObject> ClearRulesAsync(bool forwardToReplicas = false, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        {
+            return _client.ExecuteRequest(AlgoliaClient.callType.Write, "POST", string.Format("/1/indexes/{0}/rules/clear?forwardToReplicas={1}", _urlIndexName, forwardToReplicas.ToString().ToLower()), null, token, requestOptions);
+        }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.ClearRulesAsync"/>.
+        /// </summary>
+        /// <param name="forwardToReplicas">whether to forward to replicas or not (defaults to false)</param>
+        public JObject ClearRules(bool forwardToReplicas = false, RequestOptions requestOptions = null)
+        {
+            return ClearRulesAsync(forwardToReplicas, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        ///  Save a batch of new rules in the index.
+        /// </summary>
+        /// <param name="queryRules">Batch of rules to be added to the index (must contain an objectID attribute).</param>
+        /// <param name="forwardToReplicas">whether to forward to replicas or not (defaults to false)</param>
+        /// <param name="clearExistingRules">whether to clear existing rules in the index or not (defaults to false)</param>
+        public Task<JObject> BatchRulesAsync(IEnumerable<JObject> queryRules, bool forwardToReplicas = false, bool clearExistingRules = false, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        {
+            return _client.ExecuteRequest(AlgoliaClient.callType.Write, "POST", string.Format("/1/indexes/{0}/rules/batch?forwardToReplicas={1}&clearExistingRules={2}", _urlIndexName, forwardToReplicas.ToString().ToLower(), clearExistingRules.ToString().ToLower()), queryRules, token, requestOptions);
+        }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.BatchRulesAsync"/>.
+        /// </summary>
+        /// <param name="queryRules">The object to save (must contain an objectID attribute).</param>
+        /// <param name="forwardToReplicas">whether to forward to replicas or not (defaults to false)</param>
+        /// <param name="clearExistingRules">whether to clear existing rules in the index or not (defaults to false)</param>
+        public JObject BatchRules(IEnumerable<JObject> queryRules, bool forwardToReplicas = false, bool clearExistingRules = false, RequestOptions requestOptions = null)
+        {
+            return BatchRulesAsync(queryRules, forwardToReplicas, clearExistingRules, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+        }
     }
 }

--- a/Algolia.Search/Index.cs
+++ b/Algolia.Search/Index.cs
@@ -63,9 +63,11 @@ namespace Algolia.Search
         /// Add an object to this index.
         /// </summary>
         /// <param name="content">The object you want to add to the index.</param>
+        /// <param name="requestOptions"></param>
         /// <param name="objectId">Optional objectID you want to attribute to this object (if the attribute already exists the old object will be overwritten).</param>
+        /// <param name="token"></param>
         /// <returns>An object that contains an "objectID" attribute.</returns>
-        public Task<JObject> AddObjectAsync(object content, string objectId = null, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        public Task<JObject> AddObjectAsync(object content, RequestOptions requestOptions, string objectId = null, CancellationToken token = default(CancellationToken))
         {
             if (string.IsNullOrWhiteSpace(objectId))
             {
@@ -81,19 +83,22 @@ namespace Algolia.Search
         /// Synchronously call <see cref="Index.AddObjectAsync"/>.
         /// </summary>
         /// <param name="content">The object you want to add to the index.</param>
+        /// <param name="requestOptions"></param>
         /// <param name="objectId">Optional objectID you want to attribute to this object (if the attribute already exists the old object will be overwritten).</param>
         /// <returns>An object that contains an "objectID" attribute.</returns>
-        public JObject AddObject(object content, string objectId = null, RequestOptions requestOptions = null)
+        public JObject AddObject(object content, RequestOptions requestOptions, string objectId = null)
         {
-            return AddObjectAsync(content, objectId, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return AddObjectAsync(content, requestOptions, objectId, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Add several objects to this index.
         /// </summary>
         /// <param name="objects">An array of objects to add. If the objects contains objectIDs, they will be used.</param>
+        /// <param name="requestOptions"></param>
+        /// <param name="token"></param>
         /// <returns>An object containing an "objectIDs" attribute (array of string).</returns>
-        public Task<JObject> AddObjectsAsync(IEnumerable<object> objects, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        public Task<JObject> AddObjectsAsync(IEnumerable<object> objects, RequestOptions requestOptions, CancellationToken token = default(CancellationToken))
         {
             List<object> requests = new List<object>();
             foreach (object obj in objects) {
@@ -111,19 +116,22 @@ namespace Algolia.Search
         /// Synchronously call <see cref="Index.AddObjectsAsync"/>.
         /// </summary>
         /// <param name="objects">An array of objects to add. If the objects contains objectIDs, they will be used.</param>
+        /// <param name="requestOptions"></param>
         /// <returns>An object containing an "objectIDs" attribute (array of string).</returns>
-        public JObject AddObjects(IEnumerable<object> objects, RequestOptions requestOptions = null)
+        public JObject AddObjects(IEnumerable<object> objects, RequestOptions requestOptions)
         {
-            return AddObjectsAsync(objects, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return AddObjectsAsync(objects, requestOptions, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Get an object from this index.
         /// </summary>
         /// <param name="objectID">The unique identifier of the object to retrieve.</param>
+        /// <param name="requestOptions"></param>
         /// <param name="attributesToRetrieve">Optional list of attributes to retrieve.</param>
+        /// <param name="token"></param>
         /// <returns></returns>
-        public Task<JObject> GetObjectAsync(string objectID, IEnumerable<string> attributesToRetrieve = null, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        public Task<JObject> GetObjectAsync(string objectID, RequestOptions requestOptions, IEnumerable<string> attributesToRetrieve = null, CancellationToken token = default(CancellationToken))
         {
             if (attributesToRetrieve == null)
             {
@@ -146,19 +154,22 @@ namespace Algolia.Search
         /// Synchronously call <see cref="Index.GetObjectAsync"/>.
         /// </summary>
         /// <param name="objectID">The unique identifier of the object to retrieve.</param>
+        /// <param name="requestOptions"></param>
         /// <param name="attributesToRetrieve">Optional list of attributes to retrieve.</param>
         /// <returns></returns>
-        public JObject GetObject(string objectID, IEnumerable<string> attributesToRetrieve = null, RequestOptions requestOptions = null)
+        public JObject GetObject(string objectID, RequestOptions requestOptions, IEnumerable<string> attributesToRetrieve = null)
         {
-            return GetObjectAsync(objectID, attributesToRetrieve, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return GetObjectAsync(objectID, requestOptions, attributesToRetrieve, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Get several objects from this index.
         /// </summary>
         /// <param name="objectIDs">An array of unique identifiers of the objects to retrieve.</param>
+        /// <param name="requestOptions"></param>
+        /// <param name="token"></param>
         /// <returns></returns> 
-        public Task<JObject> GetObjectsAsync(IEnumerable<String> objectIDs, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        public Task<JObject> GetObjectsAsync(IEnumerable<string> objectIDs, RequestOptions requestOptions, CancellationToken token = default(CancellationToken))
         {
             JArray requests = new JArray();
             foreach (String id in objectIDs)
@@ -177,8 +188,11 @@ namespace Algolia.Search
         /// Get several objects from this index.
         /// </summary>
         /// <param name="objectIDs">An array of unique identifiers of the objects to retrieve.</param>
+        /// <param name="attributesToRetrieve"></param>
+        /// <param name="requestOptions"></param>
+        /// <param name="token"></param>
         /// <returns></returns> 
-        public Task<JObject> GetObjectsAsync(IEnumerable<String> objectIDs, IEnumerable<string> attributesToRetrieve, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        public Task<JObject> GetObjectsAsync(IEnumerable<string> objectIDs, IEnumerable<string> attributesToRetrieve, RequestOptions requestOptions, CancellationToken token = default(CancellationToken))
         {
             JArray requests = new JArray();
             var attributes = "";
@@ -208,10 +222,11 @@ namespace Algolia.Search
         /// Synchronously call <see cref="Index.GetObjectsAsync"/>.
         /// </summary>
         /// <param name="objectIDs">An array of unique identifiers of the objects to retrieve.</param>
+        /// <param name="requestOptions"></param>
         /// <returns></returns> 
-        public JObject GetObjects(IEnumerable<String> objectIDs, RequestOptions requestOptions = null)
+        public JObject GetObjects(IEnumerable<string> objectIDs, RequestOptions requestOptions)
         {
-            return GetObjectsAsync(objectIDs, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return GetObjectsAsync(objectIDs, requestOptions, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -219,18 +234,22 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="objectIDs">An array of unique identifiers of the objects to retrieve.</param>
         /// <param name="attributesToRetrieve">list of attributes to retrieve.</param>
+        /// <param name="requestOptions"></param>
         /// <returns></returns> 
-        public JObject GetObjects(IEnumerable<String> objectIDs, IEnumerable<string> attributesToRetrieve, RequestOptions requestOptions = null)
+        public JObject GetObjects(IEnumerable<string> objectIDs, IEnumerable<string> attributesToRetrieve, RequestOptions requestOptions)
         {
-            return GetObjectsAsync(objectIDs, attributesToRetrieve, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return GetObjectsAsync(objectIDs, attributesToRetrieve, requestOptions, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Partially update an object (only update attributes passed in argument).
         /// </summary>
         /// <param name="partialObject">The object attributes to override (must contains an objectID attribute).</param>
+        /// <param name="requestOptions"></param>
+        /// <param name="createIfNotExists"></param>
+        /// <param name="token"></param>
         /// <returns>An object containing an "updatedAt" attribute.</returns>
-        public Task<JObject> PartialUpdateObjectAsync(JObject partialObject, bool createIfNotExists = true, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        public Task<JObject> PartialUpdateObjectAsync(JObject partialObject, RequestOptions requestOptions, bool createIfNotExists = true, CancellationToken token = default(CancellationToken))
         {
             string queryParam = "";
             if (partialObject["objectID"] == null)
@@ -249,18 +268,23 @@ namespace Algolia.Search
         /// Synchronously call <see cref="Index.PartialUpdateObjectAsync"/>.
         /// </summary>
         /// <param name="partialObject">The object attributes to override (must contains an objectID attribute).</param>
+        /// <param name="requestOptions"></param>
+        /// <param name="createIfNotExists"></param>
         /// <returns>An object containing an "updatedAt" attribute.</returns>
-        public JObject PartialUpdateObject(JObject partialObject, bool createIfNotExists = true, RequestOptions requestOptions = null)
+        public JObject PartialUpdateObject(JObject partialObject, RequestOptions requestOptions, bool createIfNotExists = true)
         {
-            return PartialUpdateObjectAsync(partialObject, createIfNotExists, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return PartialUpdateObjectAsync(partialObject, requestOptions, createIfNotExists, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Partially update the content of several objects.
         /// </summary>
         /// <param name="objects">An array of objects to update (each object must contain an objectID attribute).</param>
+        /// <param name="requestOptions"></param>
+        /// <param name="createIfNotExists"></param>
+        /// <param name="token"></param>
         /// <returns>An object containing an "objectIDs" attribute (array of string).</returns>
-        public Task<JObject> PartialUpdateObjectsAsync(IEnumerable<JObject> objects, bool createIfNotExists = true, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        public Task<JObject> PartialUpdateObjectsAsync(IEnumerable<JObject> objects, RequestOptions requestOptions, bool createIfNotExists = true, CancellationToken token = default(CancellationToken))
         {
             string action = "partialUpdateObject";
             if (!createIfNotExists)
@@ -289,18 +313,22 @@ namespace Algolia.Search
         /// Synchronously call <see cref="Index.PartialUpdateObjectsAsync"/>.
         /// </summary>
         /// <param name="objects">An array of objects to update (each object must contain an objectID attribute).</param>
+        /// <param name="requestOptions"></param>
+        /// <param name="createIfNotExists"></param>
         /// <returns>An object containing an "objectIDs" attribute (array of string).</returns>
-        public JObject PartialUpdateObjects(IEnumerable<JObject> objects, bool createIfNotExists = true, RequestOptions requestOptions = null)
+        public JObject PartialUpdateObjects(IEnumerable<JObject> objects, RequestOptions requestOptions, bool createIfNotExists = true)
         {
-            return PartialUpdateObjectsAsync(objects, createIfNotExists, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return PartialUpdateObjectsAsync(objects, requestOptions, createIfNotExists, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Override the contents of an object.
         /// </summary>
         /// <param name="obj">The object to save (must contain an objectID attribute).</param>
+        /// <param name="requestOptions"></param>
+        /// <param name="token"></param>
         /// <returns>An object containing an "updatedAt" attribute.</returns>
-        public Task<JObject> SaveObjectAsync(JObject obj, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        public Task<JObject> SaveObjectAsync(JObject obj, RequestOptions requestOptions, CancellationToken token = default(CancellationToken))
         {
             if (obj["objectID"] == null)
             {
@@ -314,18 +342,21 @@ namespace Algolia.Search
         /// Synchronously call <see cref="Index.SaveObjectAsync"/>.
         /// </summary>
         /// <param name="obj">The object to save (must contain an objectID attribute).</param>
+        /// <param name="requestOptions"></param>
         /// <returns>An object containing an "updatedAt" attribute.</returns>
-        public JObject SaveObject(JObject obj, RequestOptions requestOptions = null)
+        public JObject SaveObject(JObject obj, RequestOptions requestOptions)
         {
-            return SaveObjectAsync(obj, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return SaveObjectAsync(obj, requestOptions, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Override the contents of several objects.
         /// </summary>
         /// <param name="objects">An array of objects to update (each object must contain an objectID attribute).</param>
+        /// <param name="requestOptions"></param>
+        /// <param name="token"></param>
         /// <returns>An object containing an "objectIDs" attribute (array of string).</returns>
-        public Task<JObject> SaveObjectsAsync(IEnumerable<JObject> objects, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        public Task<JObject> SaveObjectsAsync(IEnumerable<JObject> objects, RequestOptions requestOptions, CancellationToken token = default(CancellationToken))
         {
             List<object> requests = new List<object>();
             foreach (JObject obj in objects)
@@ -349,18 +380,21 @@ namespace Algolia.Search
         /// Synchronously call <see cref="Index.SaveObjectsAsync"/>.
         /// </summary>
         /// <param name="objects">An array of objects to update (each object must contain an objectID attribute).</param>
+        /// <param name="requestOptions"></param>
         /// <returns>An object containing an "objectIDs" attribute (array of string).</returns>
-        public JObject SaveObjects(IEnumerable<JObject> objects, RequestOptions requestOptions = null)
+        public JObject SaveObjects(IEnumerable<JObject> objects, RequestOptions requestOptions)
         {
-            return SaveObjectsAsync(objects, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return SaveObjectsAsync(objects, requestOptions, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Delete an object from the index.
         /// </summary>
         /// <param name="objectID">The unique identifier of the object to delete.</param>
+        /// <param name="requestOptions"></param>
+        /// <param name="token"></param>
         /// <returns>An object containing a "deletedAt" attribute.</returns>
-        public Task<JObject> DeleteObjectAsync(string objectID, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        public Task<JObject> DeleteObjectAsync(string objectID, RequestOptions requestOptions, CancellationToken token = default(CancellationToken))
         {
             if (string.IsNullOrWhiteSpace(objectID))
                 throw new ArgumentOutOfRangeException("objectID", "objectID is required.");
@@ -371,17 +405,20 @@ namespace Algolia.Search
         /// Synchronously call <see cref="Index.DeleteObjectAsync"/>.
         /// </summary>
         /// <param name="objectID">The unique identifier of the object to delete.</param>
+        /// <param name="requestOptions"></param>
         /// <returns>An object containing a "deletedAt" attribute.</returns>
-        public JObject DeleteObject(string objectID, RequestOptions requestOptions = null)
+        public JObject DeleteObject(string objectID, RequestOptions requestOptions)
         {
-            return DeleteObjectAsync(objectID, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return DeleteObjectAsync(objectID, requestOptions, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Delete several objects.
         /// </summary>
         /// <param name="objects">An array of objectIDs to delete.</param>
-        public Task<JObject> DeleteObjectsAsync(IEnumerable<String> objects, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        /// <param name="requestOptions"></param>
+        /// <param name="token"></param>
+        public Task<JObject> DeleteObjectsAsync(IEnumerable<string> objects, RequestOptions requestOptions, CancellationToken token = default(CancellationToken))
         {
             List<object> requests = new List<object>();
             foreach (object id in objects)
@@ -402,16 +439,18 @@ namespace Algolia.Search
         /// Synchronously call <see cref="Index.DeleteObjectsAsync"/>.
         /// </summary>
         /// <param name="objects">An array of objectIDs to delete.</param>
-        public JObject DeleteObjects(IEnumerable<String> objects, RequestOptions requestOptions = null)
+        /// <param name="requestOptions"></param>
+        public JObject DeleteObjects(IEnumerable<string> objects, RequestOptions requestOptions)
         {
-            return DeleteObjectsAsync(objects, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return DeleteObjectsAsync(objects, requestOptions, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Delete all objects matching a query.
         /// </summary>
         /// <param name="query">The query.</param>
-        async public Task DeleteByQueryAsync(Query query, RequestOptions requestOptions = null)
+        /// <param name="requestOptions"></param>
+        async public Task DeleteByQueryAsync(Query query, RequestOptions requestOptions)
         {
             query.SetAttributesToRetrieve(new string[]{"objectID"});
             query.SetAttributesToHighlight(new string[]{});
@@ -419,7 +458,7 @@ namespace Algolia.Search
             query.SetNbHitsPerPage(1000);
             query.EnableDistinct(false); // force distinct=false to improve performances
 
-            JObject result = await this.BrowseFromAsync(query, null, default(CancellationToken), requestOptions).ConfigureAwait(_client.getContinueOnCapturedContext());
+            JObject result = await this.BrowseFromAsync(query, null, requestOptions, default(CancellationToken)).ConfigureAwait(_client.getContinueOnCapturedContext());
             while (((JArray)result["hits"]).Count != 0)
             {
                 int i = 0;
@@ -429,9 +468,9 @@ namespace Algolia.Search
                 {
                     requests[i++] =  hit["objectID"].ToObject<string>();
                 }
-                var task = await this.DeleteObjectsAsync(requests).ConfigureAwait(_client.getContinueOnCapturedContext());
-                await this.WaitTaskAsync(task["taskID"].ToObject<String>()).ConfigureAwait(_client.getContinueOnCapturedContext());
-                result = await this.SearchAsync(query, default(CancellationToken), requestOptions).ConfigureAwait(_client.getContinueOnCapturedContext());
+                var task = await this.DeleteObjectsAsync(requests, requestOptions).ConfigureAwait(_client.getContinueOnCapturedContext());
+                await this.WaitTaskAsync(task["taskID"].ToObject<String>(), requestOptions).ConfigureAwait(_client.getContinueOnCapturedContext());
+                result = await this.SearchAsync(query, requestOptions, default(CancellationToken)).ConfigureAwait(_client.getContinueOnCapturedContext());
             }
         }
 
@@ -439,7 +478,8 @@ namespace Algolia.Search
         /// Synchronously call <see cref="Index.DeleteByQueryAsync"/>.
         /// </summary>
         /// <param name="query">The query.</param>
-        public void DeleteByQuery(Query query, RequestOptions requestOptions = null)
+        /// <param name="requestOptions"></param>
+        public void DeleteByQuery(Query query, RequestOptions requestOptions)
         {
             DeleteByQueryAsync(query, requestOptions).GetAwaiter().GetResult();
         }
@@ -448,7 +488,9 @@ namespace Algolia.Search
         /// Search inside the index.
         /// </summary>
         /// <param name="q">The query.</param>
-        public Task<JObject> SearchAsync(Query q, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        /// <param name="requestOptions"></param>
+        /// <param name="token"></param>
+        public Task<JObject> SearchAsync(Query q, RequestOptions requestOptions, CancellationToken token = default(CancellationToken))
         {
             string paramsString = q.GetQueryString();
             if (paramsString.Length > 0)
@@ -467,16 +509,20 @@ namespace Algolia.Search
         /// Synchronously call <see cref="Index.SearchAsync"/>.
         /// </summary>
         /// <param name="q">The query.</param>
-        public JObject Search(Query q, RequestOptions requestOptions = null)
+        /// <param name="requestOptions"></param>
+        public JObject Search(Query q, RequestOptions requestOptions)
         {
-            return SearchAsync(q, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return SearchAsync(q, requestOptions, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Check to see if the asynchronous server task is complete.
         /// </summary>
         /// <param name="taskID">The id of the task returned by server.</param>
-        async public Task WaitTaskAsync(string taskID, int timeToWait = 100, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        /// <param name="requestOptions"></param>
+        /// <param name="timeToWait"></param>
+        /// <param name="token"></param>
+        async public Task WaitTaskAsync(string taskID, RequestOptions requestOptions, int timeToWait = 100, CancellationToken token = default(CancellationToken))
         {
             while (true)
             {
@@ -495,16 +541,18 @@ namespace Algolia.Search
         /// Synchronously call <see cref="Index.WaitTaskAsync"/>.
         /// </summary>
         /// <param name="taskID">The id of the task returned by server.</param>
-        public void WaitTask(String taskID, int timeToWait = 100, RequestOptions requestOptions = null)
+        /// <param name="requestOptions"></param>
+        /// <param name="timeToWait"></param>
+        public void WaitTask(string taskID, RequestOptions requestOptions, int timeToWait = 100)
         {
-            WaitTaskAsync(taskID, timeToWait, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            WaitTaskAsync(taskID, requestOptions, timeToWait, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Get the index settings.
         /// </summary>
         /// <returns>An object containing the settings.</returns>
-        public Task<JObject> GetSettingsAsync(CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        public Task<JObject> GetSettingsAsync(RequestOptions requestOptions, CancellationToken token = default(CancellationToken))
         {
             return _client.ExecuteRequest(AlgoliaClient.callType.Read, "GET", string.Format("/1/indexes/{0}/settings?getVersion=2", _urlIndexName), null, token, requestOptions);
         }
@@ -512,18 +560,21 @@ namespace Algolia.Search
         /// <summary>
         /// Synchronously call <see cref="Index.GetSettingsAsync"/>.
         /// </summary>
+        /// <param name="requestOptions"></param>
         /// <returns>An object containing the settings.</returns>
-        public JObject GetSettings(RequestOptions requestOptions = null)
+        public JObject GetSettings(RequestOptions requestOptions)
         {
-            return GetSettingsAsync(default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return GetSettingsAsync(requestOptions, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
         ///  Browse all index contents.
         /// </summary>
+        /// <param name="requestOptions"></param>
         /// <param name="page">The page number to browse.</param>
         /// <param name="hitsPerPage">The number of hits per page.</param>
-        public Task<JObject> BrowseAsync(int page = 0, int hitsPerPage = 1000, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        /// <param name="token"></param>
+        public Task<JObject> BrowseAsync(RequestOptions requestOptions, int page = 0, int hitsPerPage = 1000, CancellationToken token = default(CancellationToken))
         {
             string param = "";
             if (page != 0)
@@ -542,11 +593,12 @@ namespace Algolia.Search
         /// <summary>
         /// Synchronously call <see cref="Index.BrowseAsync"/>.
         /// </summary>
+        /// <param name="requestOptions"></param>
         /// <param name="page">The page number to browse.</param>
         /// <param name="hitsPerPage">The number of hits per page.</param>
-        public JObject Browse(int page = 0, int hitsPerPage = 1000, RequestOptions requestOptions = null)
+        public JObject Browse(RequestOptions requestOptions, int page = 0, int hitsPerPage = 1000)
         {
-            return BrowseAsync(page, hitsPerPage, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return BrowseAsync(requestOptions, page, hitsPerPage, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -554,7 +606,9 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="q">The query parameters for the browse.</param>
         /// <param name="cursor">The cursor to start the browse can be empty.</param>
-        public Task<JObject> BrowseFromAsync(Query q, string cursor, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        /// <param name="requestOptions"></param>
+        /// <param name="token"></param>
+        public Task<JObject> BrowseFromAsync(Query q, string cursor, RequestOptions requestOptions, CancellationToken token = default(CancellationToken))
         {
             string cursorParam = "";
             if (cursor != null && cursor.Length > 0)
@@ -569,9 +623,10 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="q">The query parameters for the browse.</param>
         /// <param name="cursor">The cursor to start the browse can be empty.</param>
-        public JObject BrowseFrom(Query q, string cursor, RequestOptions requestOptions = null)
+        /// <param name="requestOptions"></param>
+        public JObject BrowseFrom(Query q, string cursor, RequestOptions requestOptions)
         {
-            return BrowseFromAsync(q, cursor, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return BrowseFromAsync(q, cursor, requestOptions, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         public class IndexIterator : IEnumerable<JObject> {
@@ -618,7 +673,7 @@ namespace Algolia.Search
             private void LoadNextPage() {
                 pos = 0;
                 string cursor = GetCursor();
-                answer = index.BrowseFromAsync(query, cursor).GetAwaiter().GetResult();
+                answer = index.BrowseFromAsync(query, cursor, null).GetAwaiter().GetResult();
             }
 
             public string GetCursor()
@@ -673,7 +728,7 @@ namespace Algolia.Search
         ///  Browse all index contents.
         /// </summary>
         /// <param name="q">The query parameters for the browse.</param>
-        public IndexIterator BrowseAll(Query q, RequestOptions requestOptions = null)
+        public IndexIterator BrowseAll(Query q)
         {
             return new IndexIterator(this, q, "");
         }
@@ -681,7 +736,7 @@ namespace Algolia.Search
         /// <summary>
         /// Delete the index contents without removing settings and index specific API keys.
         /// </summary>
-        public Task<JObject> ClearIndexAsync(CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        public Task<JObject> ClearIndexAsync(RequestOptions requestOptions, CancellationToken token = default(CancellationToken))
         {
             return _client.ExecuteRequest(AlgoliaClient.callType.Write, "POST", string.Format("/1/indexes/{0}/clear", _urlIndexName), null, token, requestOptions);
         }
@@ -689,57 +744,60 @@ namespace Algolia.Search
         /// <summary>
         /// Synchronously call <see cref="Index.ClearIndexAsync"/>.
         /// </summary>
-        public JObject ClearIndex(RequestOptions requestOptions = null)
+        /// <param name="requestOptions"></param>
+        public JObject ClearIndex(RequestOptions requestOptions)
         {
-            return ClearIndexAsync(default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return ClearIndexAsync(requestOptions, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Set the settings for this index.
         /// </summary>
         /// <param name="settings">The settings object can contain:
-        ///  - minWordSizefor1Typo: (integer) the minimum number of characters to accept one typo (default = 3).
-        ///  - minWordSizefor2Typos: (integer) the minimum number of characters to accept two typos (default = 7).
-        ///  - hitsPerPage: (integer) the number of hits per page (default = 10).
-        ///  - attributesToRetrieve: (array of strings) default list of attributes to retrieve in objects. 
-        ///    If set to null, all attributes are retrieved.
-        ///  - attributesToHighlight: (array of strings) default list of attributes to highlight. 
-        ///    If set to null, all indexed attributes are highlighted.
-        ///  - attributesToSnippet**: (array of strings) default list of attributes to snippet alongside the number of words to return (syntax is attributeName:nbWords).
-        ///    By default no snippet is computed. If set to null, no snippet is computed.
-        ///  - searchableAttributes(formerly attributesToIndex): (array of strings) the list of fields you want to index.
-        ///    If set to null, all textual and numerical attributes of your objects are indexed, but you should update it to get optimal results.
-        ///    This parameter has two important uses:
-        ///      - Limit the attributes to index: For example if you store a binary image in base64, you want to store it and be able to 
-        ///        retrieve it but you don't want to search in the base64 string.
-        ///      - Control part of the ranking*: (see the ranking parameter for full explanation) Matches in attributes at the beginning of 
-        ///        the list will be considered more important than matches in attributes further down the list. 
-        ///        In one attribute, matching text at the beginning of the attribute will be considered more important than text after, you can disable 
-        ///        this behavior if you add your attribute inside `unordered(AttributeName)`, for example searchableAttributes: ["title", "unordered(text)"].
-        ///  - attributesForFaceting: (array of strings) The list of fields you want to use for faceting. 
-        ///    All strings in the attribute selected for faceting are extracted and added as a facet. If set to null, no attribute is used for faceting.
-        ///  - ranking: (array of strings) controls the way results are sorted.
-        ///    We have six available criteria: 
+        ///     - minWordSizefor1Typo: (integer) the minimum number of characters to accept one typo (default = 3).
+        ///     - minWordSizefor2Typos: (integer) the minimum number of characters to accept two typos (default = 7).
+        ///     - hitsPerPage: (integer) the number of hits per page (default = 10).
+        ///     - attributesToRetrieve: (array of strings) default list of attributes to retrieve in objects. 
+        ///     If set to null, all attributes are retrieved.
+        ///     - attributesToHighlight: (array of strings) default list of attributes to highlight. 
+        ///     If set to null, all indexed attributes are highlighted.
+        ///     - attributesToSnippet**: (array of strings) default list of attributes to snippet alongside the number of words to return (syntax is attributeName:nbWords).
+        ///     By default no snippet is computed. If set to null, no snippet is computed.
+        ///     - searchableAttributes(formerly attributesToIndex): (array of strings) the list of fields you want to index.
+        ///     If set to null, all textual and numerical attributes of your objects are indexed, but you should update it to get optimal results.
+        ///     This parameter has two important uses:
+        ///     - Limit the attributes to index: For example if you store a binary image in base64, you want to store it and be able to 
+        ///     retrieve it but you don't want to search in the base64 string.
+        ///     - Control part of the ranking*: (see the ranking parameter for full explanation) Matches in attributes at the beginning of 
+        ///     the list will be considered more important than matches in attributes further down the list. 
+        ///     In one attribute, matching text at the beginning of the attribute will be considered more important than text after, you can disable 
+        ///     this behavior if you add your attribute inside `unordered(AttributeName)`, for example searchableAttributes: ["title", "unordered(text)"].
+        ///     - attributesForFaceting: (array of strings) The list of fields you want to use for faceting. 
+        ///     All strings in the attribute selected for faceting are extracted and added as a facet. If set to null, no attribute is used for faceting.
+        ///     - ranking: (array of strings) controls the way results are sorted.
+        ///     We have six available criteria: 
         ///     - typo: sort according to number of typos,
         ///     - geo: sort according to decreassing distance when performing a geo-location based search,
         ///     - proximity: sort according to the proximity of query words in hits,
         ///     - attribute: sort according to the order of attributes defined by searchableAttributes,
         ///     - exact: sort according to the number of words that are matched identical to query word (and not as a prefix),
         ///     - custom: sort according to a user defined formula set in **customRanking** attribute.
-        ///    The standard order is ["typo", "geo", "proximity", "attribute", "exact", "custom"]
-        ///  - customRanking: (array of strings) lets you specify part of the ranking.
-        ///    The syntax of this condition is an array of strings containing attributes prefixed by asc (ascending order) or desc (descending order) operator.
-        ///    For example `"customRanking" => ["desc(population)", "asc(name)"]`  
-        ///  - queryType: Select how the query words are interpreted, it can be one of the following value:
-        ///    - prefixAll: all query words are interpreted as prefixes,
-        ///    - prefixLast: only the last word is interpreted as a prefix (default behavior),
-        ///    - prefixNone: no query word is interpreted as a prefix. This option is not recommended.
-        ///  - highlightPreTag: (string) Specify the string that is inserted before the highlighted parts in the query result (default to "<em>").
-        ///  - highlightPostTag: (string) Specify the string that is inserted after the highlighted parts in the query result (default to "</em>").
-        ///  - optionalWords: (array of strings) Specify a list of words that should be considered as optional when found in the query.
+        ///     The standard order is ["typo", "geo", "proximity", "attribute", "exact", "custom"]
+        ///     - customRanking: (array of strings) lets you specify part of the ranking.
+        ///     The syntax of this condition is an array of strings containing attributes prefixed by asc (ascending order) or desc (descending order) operator.
+        ///     For example `"customRanking" => ["desc(population)", "asc(name)"]`  
+        ///     - queryType: Select how the query words are interpreted, it can be one of the following value:
+        ///     - prefixAll: all query words are interpreted as prefixes,
+        ///     - prefixLast: only the last word is interpreted as a prefix (default behavior),
+        ///     - prefixNone: no query word is interpreted as a prefix. This option is not recommended.
+        ///     - highlightPreTag: (string) Specify the string that is inserted before the highlighted parts in the query result (default to "<em>").
+        ///         - highlightPostTag: (string) Specify the string that is inserted after the highlighted parts in the query result (default to "</em>").
+        ///     - optionalWords: (array of strings) Specify a list of words that should be considered as optional when found in the query.
         /// </param>
+        /// <param name="requestOptions"></param>
         /// <param name="forwardToReplicas">Forward the operation to the replica indices</param>
-        public Task<JObject> SetSettingsAsync(JObject settings, bool forwardToReplicas = false, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        /// <param name="token"></param>
+        public Task<JObject> SetSettingsAsync(JObject settings, RequestOptions requestOptions, bool forwardToReplicas = false, CancellationToken token = default(CancellationToken))
         {
             string changeSettingsPath = forwardToReplicas
                 ? string.Format("/1/indexes/{0}/settings?forwardToReplicas={1}", _urlIndexName, forwardToReplicas.ToString().ToLower())
@@ -750,16 +808,16 @@ namespace Algolia.Search
         /// <summary>
         /// Synchronously call <see cref="Index.SetSettingsAsync"/>.
         /// </summary>
-        public JObject SetSettings(JObject settings, bool forwardToReplicas = false, RequestOptions requestOptions = null)
+        public JObject SetSettings(JObject settings, RequestOptions requestOptions, bool forwardToReplicas = false)
         {
-            return SetSettingsAsync(settings, forwardToReplicas, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return SetSettingsAsync(settings, requestOptions, forwardToReplicas, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// List all user keys associated with this index along with their associated ACLs.
         /// </summary>
         [Obsolete("ListUserKeysAsync is deprecated, please use ListApiKeysAsync instead.")]
-        public Task<JObject> ListUserKeysAsync(CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        public Task<JObject> ListUserKeysAsync(RequestOptions requestOptions, CancellationToken token = default(CancellationToken))
         {
             return _client.ExecuteRequest(AlgoliaClient.callType.Read, "GET", string.Format("/1/indexes/{0}/keys", _urlIndexName), null, token, requestOptions);
         }
@@ -767,7 +825,7 @@ namespace Algolia.Search
         /// <summary>
         /// List all api keys associated with this index along with their associated ACLs.
         /// </summary>
-        public Task<JObject> ListApiKeysAsync(CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        public Task<JObject> ListApiKeysAsync(RequestOptions requestOptions, CancellationToken token = default(CancellationToken))
         {
             return _client.ExecuteRequest(AlgoliaClient.callType.Read, "GET", string.Format("/1/indexes/{0}/keys", _urlIndexName), null, token, requestOptions);
         }
@@ -775,25 +833,27 @@ namespace Algolia.Search
         /// <summary>
         /// Synchronously call <see cref="Index.ListApiKeysAsync"/>.
         /// </summary>
+        /// <param name="requestOptions"></param>
         [Obsolete("ListUserKeys is deprecated, please use ListApiKeys instead.")]
-        public JObject ListUserKeys(RequestOptions requestOptions = null)
+        public JObject ListUserKeys(RequestOptions requestOptions)
         {
-            return ListApiKeysAsync(default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return ListApiKeysAsync(requestOptions, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Synchronously call <see cref="Index.ListApiKeysAsync"/>.
         /// </summary>
-        public JObject ListApiKeys(RequestOptions requestOptions = null)
+        /// <param name="requestOptions"></param>
+        public JObject ListApiKeys(RequestOptions requestOptions)
         {
-            return ListApiKeysAsync(default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return ListApiKeysAsync(requestOptions, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Get ACL of a user key associated with this index.
         /// </summary>
         [Obsolete("GetUserKeyACLAsync is deprecated, please use GetUserApiACLAsync instead.")]
-        public Task<JObject> GetUserKeyACLAsync(string key, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        public Task<JObject> GetUserKeyACLAsync(string key, RequestOptions requestOptions, CancellationToken token = default(CancellationToken))
         {
             return _client.ExecuteRequest(AlgoliaClient.callType.Read, "GET", string.Format("/1/indexes/{0}/keys/{1}", _urlIndexName, key), null, token, requestOptions);
         }
@@ -801,7 +861,7 @@ namespace Algolia.Search
         /// <summary>
         /// Get ACL of an api key associated with this index.
         /// </summary>
-        public Task<JObject> GetApiKeyACLAsync(string key, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        public Task<JObject> GetApiKeyACLAsync(string key, RequestOptions requestOptions, CancellationToken token = default(CancellationToken))
         {
             return _client.ExecuteRequest(AlgoliaClient.callType.Read, "GET", string.Format("/1/indexes/{0}/keys/{1}", _urlIndexName, key), null, token, requestOptions);
         }
@@ -810,24 +870,24 @@ namespace Algolia.Search
         /// Synchronously call <see cref="Index.GetUserKeyACLAsync"/>.
         /// </summary>
         [Obsolete("GetUserKeyACL is deprecated, please use GetApiKeyACL instead.")]
-        public JObject GetUserKeyACL(string key, RequestOptions requestOptions = null)
+        public JObject GetUserKeyACL(string key, RequestOptions requestOptions)
         {
-            return GetApiKeyACLAsync(key, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return GetApiKeyACLAsync(key, requestOptions, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Synchronously call <see cref="Index.GetApiKeyACLAsync"/>.
         /// </summary>
-        public JObject GetApiKeyACL(string key, RequestOptions requestOptions = null)
+        public JObject GetApiKeyACL(string key, RequestOptions requestOptions)
         {
-            return GetApiKeyACLAsync(key, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return GetApiKeyACLAsync(key, requestOptions, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Delete an existing user key associated with this index.
         /// </summary>
         [Obsolete("DeleteUserKeyAsync is deprecated, please use DeleteApiKeyAsync instead.")]
-        public Task<JObject> DeleteUserKeyAsync(string key, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        public Task<JObject> DeleteUserKeyAsync(string key, RequestOptions requestOptions, CancellationToken token = default(CancellationToken))
         {
             return _client.ExecuteRequest(AlgoliaClient.callType.Write, "DELETE", string.Format("/1/indexes/{0}/keys/{1}", _urlIndexName, key), null, token, requestOptions);
         }
@@ -835,7 +895,7 @@ namespace Algolia.Search
         /// <summary>
         /// Delete an existing api key associated with this index.
         /// </summary>
-        public Task<JObject> DeleteApiKeyAsync(string key, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        public Task<JObject> DeleteApiKeyAsync(string key, RequestOptions requestOptions, CancellationToken token = default(CancellationToken))
         {
             return _client.ExecuteRequest(AlgoliaClient.callType.Write, "DELETE", string.Format("/1/indexes/{0}/keys/{1}", _urlIndexName, key), null, token, requestOptions);
         }
@@ -844,34 +904,36 @@ namespace Algolia.Search
         /// Synchronously call <see cref="Index.DeleteApiKeyAsync"/>.
         /// </summary>
         [Obsolete("DeleteUserKey is deprecated, please use DeleteApiKey instead.")]
-        public JObject DeleteUserKey(string key, RequestOptions requestOptions = null)
+        public JObject DeleteUserKey(string key, RequestOptions requestOptions)
         {
-            return DeleteApiKeyAsync(key, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return DeleteApiKeyAsync(key, requestOptions, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Synchronously call <see cref="Index.DeleteApiKeyAsync"/>.
         /// </summary>
-        public JObject DeleteApiKey(string key, RequestOptions requestOptions = null)
+        public JObject DeleteApiKey(string key, RequestOptions requestOptions)
         {
-            return DeleteApiKeyAsync(key, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return DeleteApiKeyAsync(key, requestOptions, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Create a new user key associated with this index.
         /// </summary>
         /// <param name="parameters">the list of parameters for this key. Defined by a Dictionnary that 
-        /// can contains the following values:
-        ///   - acl: array of string
-        ///   - validity: int
-        ///   - referers: array of string
-        ///   - description: string
-        ///   - maxHitsPerQuery: integer
-        ///   - queryParameters: string
-        ///   - maxQueriesPerIPPerHour: integer
-        /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
+        ///     can contains the following values:
+        ///     - acl: array of string
+        ///     - validity: int
+        ///     - referers: array of string
+        ///     - description: string
+        ///     - maxHitsPerQuery: integer
+        ///     - queryParameters: string
+        ///     - maxQueriesPerIPPerHour: integer
+        ///     <returns>Returns an object with a "key" string attribute containing the new key.</returns>
+        /// <param name="requestOptions"></param>
+        /// <param name="token"></param>
         [Obsolete("AddUserKeyAsync is deprecated, please use AddApiKeyAsync instead.")]
-        public Task<JObject> AddUserKeyAsync(Dictionary<string, object> parameters, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        public Task<JObject> AddUserKeyAsync(Dictionary<string, object> parameters, RequestOptions requestOptions, CancellationToken token = default(CancellationToken))
         {
             return _client.ExecuteRequest(AlgoliaClient.callType.Write, "POST", string.Format("/1/indexes/{0}/keys", _urlIndexName), parameters, token, requestOptions);
         }
@@ -880,16 +942,18 @@ namespace Algolia.Search
         /// Create a new api key associated with this index.
         /// </summary>
         /// <param name="parameters">the list of parameters for this key. Defined by a Dictionnary that 
-        /// can contains the following values:
-        ///   - acl: array of string
-        ///   - validity: int
-        ///   - referers: array of string
-        ///   - description: string
-        ///   - maxHitsPerQuery: integer
-        ///   - queryParameters: string
-        ///   - maxQueriesPerIPPerHour: integer
-        /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
-        public Task<JObject> AddApiKeyAsync(Dictionary<string, object> parameters, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        ///     can contains the following values:
+        ///     - acl: array of string
+        ///     - validity: int
+        ///     - referers: array of string
+        ///     - description: string
+        ///     - maxHitsPerQuery: integer
+        ///     - queryParameters: string
+        ///     - maxQueriesPerIPPerHour: integer
+        ///     <returns>Returns an object with a "key" string attribute containing the new key.</returns>
+        /// <param name="requestOptions"></param>
+        /// <param name="token"></param>
+        public Task<JObject> AddApiKeyAsync(Dictionary<string, object> parameters, RequestOptions requestOptions, CancellationToken token = default(CancellationToken))
         {
             return _client.ExecuteRequest(AlgoliaClient.callType.Write, "POST", string.Format("/1/indexes/{0}/keys", _urlIndexName), parameters, token, requestOptions);
         }
@@ -898,83 +962,85 @@ namespace Algolia.Search
         /// Synchronously call <see cref="Index.AddApiKeyAsync"/>.
         /// </summary>
         [Obsolete("AddUserKey is deprecated, please use AddApiKey instead.")]
-        public JObject AddUserKey(Dictionary<string, object> parameters, RequestOptions requestOptions = null)
+        public JObject AddUserKey(Dictionary<string, object> parameters, RequestOptions requestOptions)
         {
-            return AddApiKeyAsync(parameters, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return AddApiKeyAsync(parameters, requestOptions, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Synchronously call <see cref="Index.AddApiKeyAsync"/>.
         /// </summary>
-        public JObject AddApiKey(Dictionary<string, object> parameters, RequestOptions requestOptions = null)
+        public JObject AddApiKey(Dictionary<string, object> parameters, RequestOptions requestOptions)
         {
-            return AddApiKeyAsync(parameters, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return AddApiKeyAsync(parameters, requestOptions, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Create a new user key associated with this index.
         /// </summary>
         /// <param name="acls">The list of ACL for this key. Defined by an array of strings that can contains the following values:
-        ///   - search: allow searching (https and http)
-        ///   - addObject: allow adding/updating an object in the index (https only)
-        ///   - deleteObject : allow deleting an existing object (https only)
-        ///   - deleteIndex : allow deleting an index (https only)
-        ///   - settings : allow getting index settings (https only)
-        ///   - editSettings : allow changing index settings (https only)</param>
+        ///     - search: allow searching (https and http)
+        ///     - addObject: allow adding/updating an object in the index (https only)
+        ///     - deleteObject : allow deleting an existing object (https only)
+        ///     - deleteIndex : allow deleting an index (https only)
+        ///     - settings : allow getting index settings (https only)
+        ///     - editSettings : allow changing index settings (https only)</param>
+        /// <param name="requestOptions"></param>
         /// <param name="validity">The number of seconds after which the key will be automatically removed (0 means no time limit for this key).</param>
         /// <param name="maxQueriesPerIPPerHour">Specify the maximum number of API calls allowed from an IP address per hour.  Defaults to 0 (no rate limit).</param>
         /// <param name="maxHitsPerQuery">Specify the maximum number of hits this API key can retrieve in one call. Defaults to 0 (unlimited).</param>
         /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
         [Obsolete("AddUserKeyAsync is deprecated, please use AddApiKeyAsync instead.")]
-        public Task<JObject> AddUserKeyAsync(IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, RequestOptions requestOptions = null)
+        public Task<JObject> AddUserKeyAsync(IEnumerable<string> acls, RequestOptions requestOptions, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0)
         {
             Dictionary<string, object> content = new Dictionary<string, object>();
             content["acl"] = acls;
             content["validity"] = validity;
             content["maxQueriesPerIPPerHour"] = maxQueriesPerIPPerHour;
             content["maxHitsPerQuery"] = maxHitsPerQuery;
-            return AddApiKeyAsync(content, default(CancellationToken), requestOptions);
+            return AddApiKeyAsync(content, requestOptions, default(CancellationToken));
         }
 
         /// <summary>
         /// Create a new api key associated with this index.
         /// </summary>
         /// <param name="acls">The list of ACL for this key. Defined by an array of strings that can contains the following values:
-        ///   - search: allow searching (https and http)
-        ///   - addObject: allow adding/updating an object in the index (https only)
-        ///   - deleteObject : allow deleting an existing object (https only)
-        ///   - deleteIndex : allow deleting an index (https only)
-        ///   - settings : allow getting index settings (https only)
-        ///   - editSettings : allow changing index settings (https only)</param>
+        ///     - search: allow searching (https and http)
+        ///     - addObject: allow adding/updating an object in the index (https only)
+        ///     - deleteObject : allow deleting an existing object (https only)
+        ///     - deleteIndex : allow deleting an index (https only)
+        ///     - settings : allow getting index settings (https only)
+        ///     - editSettings : allow changing index settings (https only)</param>
+        /// <param name="requestOptions"></param>
         /// <param name="validity">The number of seconds after which the key will be automatically removed (0 means no time limit for this key).</param>
         /// <param name="maxQueriesPerIPPerHour">Specify the maximum number of API calls allowed from an IP address per hour.  Defaults to 0 (no rate limit).</param>
         /// <param name="maxHitsPerQuery">Specify the maximum number of hits this API key can retrieve in one call. Defaults to 0 (unlimited).</param>
         /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
-        public Task<JObject> AddApiKeyAsync(IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, RequestOptions requestOptions = null)
+        public Task<JObject> AddApiKeyAsync(IEnumerable<string> acls, RequestOptions requestOptions, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0)
         {
             Dictionary<string, object> content = new Dictionary<string, object>();
             content["acl"] = acls;
             content["validity"] = validity;
             content["maxQueriesPerIPPerHour"] = maxQueriesPerIPPerHour;
             content["maxHitsPerQuery"] = maxHitsPerQuery;
-            return AddApiKeyAsync(content, default(CancellationToken), requestOptions);
+            return AddApiKeyAsync(content, requestOptions, default(CancellationToken));
         }
 
         /// <summary>
         /// Synchronously call <see cref="Index.AddApiKeyAsync"/>.
         /// </summary>
         [Obsolete("AddUserKey is deprecated, please use AddApiKey instead.")]
-        public JObject AddUserKey(IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, RequestOptions requestOptions = null)
+        public JObject AddUserKey(IEnumerable<string> acls, RequestOptions requestOptions, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0)
         {
-            return AddApiKeyAsync(acls, validity, maxQueriesPerIPPerHour, maxHitsPerQuery, requestOptions).GetAwaiter().GetResult();
+            return AddApiKeyAsync(acls, requestOptions, validity, maxQueriesPerIPPerHour, maxHitsPerQuery).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Synchronously call <see cref="Index.AddApiKeyAsync"/>.
         /// </summary>
-        public JObject AddApiKey(IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, RequestOptions requestOptions = null)
+        public JObject AddApiKey(IEnumerable<string> acls, RequestOptions requestOptions, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0)
         {
-            return AddApiKeyAsync(acls, validity, maxQueriesPerIPPerHour, maxHitsPerQuery, requestOptions).GetAwaiter().GetResult();
+            return AddApiKeyAsync(acls, requestOptions, validity, maxQueriesPerIPPerHour, maxHitsPerQuery).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -982,17 +1048,19 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="key">The user key</param>
         /// <param name="parameters">the list of parameters for this key. Defined by a Dictionnary that 
-        /// can contains the following values:
-        ///   - acl: array of string
-        ///   - validity: int
-        ///   - referers: array of string
-        ///   - description: string
-        ///   - maxHitsPerQuery: integer
-        ///   - queryParameters: string
-        ///   - maxQueriesPerIPPerHour: integer
-        /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
+        ///     can contains the following values:
+        ///     - acl: array of string
+        ///     - validity: int
+        ///     - referers: array of string
+        ///     - description: string
+        ///     - maxHitsPerQuery: integer
+        ///     - queryParameters: string
+        ///     - maxQueriesPerIPPerHour: integer
+        ///     <returns>Returns an object with a "key" string attribute containing the new key.</returns>
+        /// <param name="requestOptions"></param>
+        /// <param name="token"></param>
         [Obsolete("UpdateUserKeyAsync is deprecated, please use UpdateApiKeyAsync instead.")]
-        public Task<JObject> UpdateUserKeyAsync(string key, Dictionary<string, object> parameters, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        public Task<JObject> UpdateUserKeyAsync(string key, Dictionary<string, object> parameters, RequestOptions requestOptions, CancellationToken token = default(CancellationToken))
         {
             return _client.ExecuteRequest(AlgoliaClient.callType.Write, "PUT", string.Format("/1/indexes/{0}/keys/{1}", _urlIndexName, key), parameters, token, requestOptions);
         }
@@ -1003,16 +1071,18 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="key">The user key</param>
         /// <param name="parameters">the list of parameters for this key. Defined by a Dictionnary that 
-        /// can contains the following values:
-        ///   - acl: array of string
-        ///   - validity: int
-        ///   - referers: array of string
-        ///   - description: string
-        ///   - maxHitsPerQuery: integer
-        ///   - queryParameters: string
-        ///   - maxQueriesPerIPPerHour: integer
-        /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
-        public Task<JObject> UpdateApiKeyAsync(string key, Dictionary<string, object> parameters, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        ///     can contains the following values:
+        ///     - acl: array of string
+        ///     - validity: int
+        ///     - referers: array of string
+        ///     - description: string
+        ///     - maxHitsPerQuery: integer
+        ///     - queryParameters: string
+        ///     - maxQueriesPerIPPerHour: integer
+        ///     <returns>Returns an object with a "key" string attribute containing the new key.</returns>
+        /// <param name="requestOptions"></param>
+        /// <param name="token"></param>
+        public Task<JObject> UpdateApiKeyAsync(string key, Dictionary<string, object> parameters, RequestOptions requestOptions, CancellationToken token = default(CancellationToken))
         {
             return _client.ExecuteRequest(AlgoliaClient.callType.Write, "PUT", string.Format("/1/indexes/{0}/keys/{1}", _urlIndexName, key), parameters, token, requestOptions);
         }
@@ -1021,17 +1091,17 @@ namespace Algolia.Search
         /// Synchronously call <see cref="Index.UpdateApiKeyAsync"/>.
         /// </summary>
         [Obsolete("UpdateUserKey is deprecated, please use UpdateApiKey instead.")]
-        public JObject UpdateUserKey(string key, Dictionary<string, object> parameters, RequestOptions requestOptions = null)
+        public JObject UpdateUserKey(string key, Dictionary<string, object> parameters, RequestOptions requestOptions)
         {
-            return UpdateApiKeyAsync(key, parameters, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return UpdateApiKeyAsync(key, parameters, requestOptions, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Synchronously call <see cref="Index.UpdateApiKeyAsync"/>.
         /// </summary>
-        public JObject UpdateApiKey(string key, Dictionary<string, object> parameters, RequestOptions requestOptions = null)
+        public JObject UpdateApiKey(string key, Dictionary<string, object> parameters, RequestOptions requestOptions)
         {
-            return UpdateApiKeyAsync(key, parameters, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return UpdateApiKeyAsync(key, parameters, requestOptions, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -1039,25 +1109,26 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="key">The user key</param>
         /// <param name="acls">The list of ACL for this key. Defined by an array of strings that can contains the following values:
-        ///   - search: allow searching (https and http)
-        ///   - addObject: allow adding/updating an object in the index (https only)
-        ///   - deleteObject : allow deleting an existing object (https only)
-        ///   - deleteIndex : allow deleting an index (https only)
-        ///   - settings : allow getting index settings (https only)
-        ///   - editSettings : allow changing index settings (https only)</param>
+        ///     - search: allow searching (https and http)
+        ///     - addObject: allow adding/updating an object in the index (https only)
+        ///     - deleteObject : allow deleting an existing object (https only)
+        ///     - deleteIndex : allow deleting an index (https only)
+        ///     - settings : allow getting index settings (https only)
+        ///     - editSettings : allow changing index settings (https only)</param>
+        /// <param name="requestOptions"></param>
         /// <param name="validity">The number of seconds after which the key will be automatically removed (0 means no time limit for this key).</param>
         /// <param name="maxQueriesPerIPPerHour">Specify the maximum number of API calls allowed from an IP address per hour.  Defaults to 0 (no rate limit).</param>
         /// <param name="maxHitsPerQuery">Specify the maximum number of hits this API key can retrieve in one call. Defaults to 0 (unlimited).</param>
         /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
         [Obsolete("UpdateUserKeyAsync is deprecated, please use UpdateApiKeyAsync instead.")]
-        public Task<JObject> UpdateUserKeyAsync(string key, IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, RequestOptions requestOptions = null)
+        public Task<JObject> UpdateUserKeyAsync(string key, IEnumerable<string> acls, RequestOptions requestOptions, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0)
         {
             Dictionary<string, object> content = new Dictionary<string, object>();
             content["acl"] = acls;
             content["validity"] = validity;
             content["maxQueriesPerIPPerHour"] = maxQueriesPerIPPerHour;
             content["maxHitsPerQuery"] = maxHitsPerQuery;
-            return UpdateApiKeyAsync(key, content, default(CancellationToken), requestOptions);
+            return UpdateApiKeyAsync(key, content, requestOptions, default(CancellationToken));
         }
 
         /// <summary>
@@ -1065,41 +1136,42 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="key">The user key</param>
         /// <param name="acls">The list of ACL for this key. Defined by an array of strings that can contains the following values:
-        ///   - search: allow searching (https and http)
-        ///   - addObject: allow adding/updating an object in the index (https only)
-        ///   - deleteObject : allow deleting an existing object (https only)
-        ///   - deleteIndex : allow deleting an index (https only)
-        ///   - settings : allow getting index settings (https only)
-        ///   - editSettings : allow changing index settings (https only)</param>
+        ///     - search: allow searching (https and http)
+        ///     - addObject: allow adding/updating an object in the index (https only)
+        ///     - deleteObject : allow deleting an existing object (https only)
+        ///     - deleteIndex : allow deleting an index (https only)
+        ///     - settings : allow getting index settings (https only)
+        ///     - editSettings : allow changing index settings (https only)</param>
+        /// <param name="requestOptions"></param>
         /// <param name="validity">The number of seconds after which the key will be automatically removed (0 means no time limit for this key).</param>
         /// <param name="maxQueriesPerIPPerHour">Specify the maximum number of API calls allowed from an IP address per hour.  Defaults to 0 (no rate limit).</param>
         /// <param name="maxHitsPerQuery">Specify the maximum number of hits this API key can retrieve in one call. Defaults to 0 (unlimited).</param>
         /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
-        public Task<JObject> UpdateApiKeyAsync(string key, IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, RequestOptions requestOptions = null)
+        public Task<JObject> UpdateApiKeyAsync(string key, IEnumerable<string> acls, RequestOptions requestOptions, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0)
         {
             Dictionary<string, object> content = new Dictionary<string, object>();
             content["acl"] = acls;
             content["validity"] = validity;
             content["maxQueriesPerIPPerHour"] = maxQueriesPerIPPerHour;
             content["maxHitsPerQuery"] = maxHitsPerQuery;
-            return UpdateApiKeyAsync(key, content, default(CancellationToken), requestOptions);
+            return UpdateApiKeyAsync(key, content, requestOptions, default(CancellationToken));
         }
 
         /// <summary>
         /// Synchronously call <see cref="Index.UpdateApiKeyAsync"/>.
         /// </summary>
         [Obsolete("UpdateUserKey is deprecated, please use UpdateApiKey instead.")]
-        public JObject UpdateUserKey(string key, IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, RequestOptions requestOptions = null)
+        public JObject UpdateUserKey(string key, IEnumerable<string> acls, RequestOptions requestOptions, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0)
         {
-            return UpdateApiKeyAsync(key, acls, validity, maxQueriesPerIPPerHour, maxHitsPerQuery, requestOptions).GetAwaiter().GetResult();
+            return UpdateApiKeyAsync(key, acls, requestOptions, validity, maxQueriesPerIPPerHour, maxHitsPerQuery).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Synchronously call <see cref="Index.UpdateApiKeyAsync"/>.
         /// </summary>
-        public JObject UpdateApiKey(string key, IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, RequestOptions requestOptions = null)
+        public JObject UpdateApiKey(string key, IEnumerable<string> acls, RequestOptions requestOptions, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0)
         {
-            return UpdateApiKeyAsync(key, acls, validity, maxQueriesPerIPPerHour, maxHitsPerQuery, requestOptions).GetAwaiter().GetResult();
+            return UpdateApiKeyAsync(key, acls, requestOptions, validity, maxQueriesPerIPPerHour, maxHitsPerQuery).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -1107,8 +1179,9 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="query">The query.</param>
         /// <param name="disjunctiveFacets">The array of disjunctive facets.</param>
+        /// <param name="requestOptions"></param>
         /// <param name="refinements">The current refinements. Example: { "my_facet1" => ["my_value1", "my_value2"], "my_disjunctive_facet1" => ["my_value1", "my_value2"] }.</param>
-        async public Task<JObject> SearchDisjunctiveFacetingAsync(Query query, IEnumerable<string> disjunctiveFacets, Dictionary<string, IEnumerable<string>> refinements = null, RequestOptions requestOptions = null)
+        async public Task<JObject> SearchDisjunctiveFacetingAsync(Query query, IEnumerable<string> disjunctiveFacets, RequestOptions requestOptions, Dictionary<string, IEnumerable<string>> refinements = null)
         {
             if (refinements == null)
                 refinements = new Dictionary<string, IEnumerable<string>>();
@@ -1186,7 +1259,7 @@ namespace Algolia.Search
                 queries.Add(new IndexQuery(_indexName, query.clone().SetPage(0).SetNbHitsPerPage(0).EnableAnalytics(false).SetAttributesToRetrieve(new List<string>()).SetAttributesToHighlight(new List<string>()).SetAttributesToSnippet(new List<string>()).SetFacets(new String[]{disjunctiveFacet}).SetFacetFilters(filters)));
             }
         
-            JObject answers = await _client.MultipleQueriesAsync(queries, "none", default(CancellationToken), requestOptions).ConfigureAwait(_client.getContinueOnCapturedContext());
+            JObject answers = await _client.MultipleQueriesAsync(queries, requestOptions, "none", default(CancellationToken)).ConfigureAwait(_client.getContinueOnCapturedContext());
 
             // aggregate answers
             // first answer stores the hits + regular facets
@@ -1225,9 +1298,9 @@ namespace Algolia.Search
         /// <summary>
         /// Synchronously call <see cref="Index.UpdateUserKeyAsync"/>.
         /// </summary>
-        public JObject SearchDisjunctiveFaceting(Query query, IEnumerable<string> disjunctiveFacets, Dictionary<string, IEnumerable<string>> refinements = null, RequestOptions requestOptions = null)
+        public JObject SearchDisjunctiveFaceting(Query query, IEnumerable<string> disjunctiveFacets, RequestOptions requestOptions, Dictionary<string, IEnumerable<string>> refinements = null)
         {
-            return SearchDisjunctiveFacetingAsync(query, disjunctiveFacets, refinements, requestOptions).GetAwaiter().GetResult();
+            return SearchDisjunctiveFacetingAsync(query, disjunctiveFacets, requestOptions, refinements).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -1262,10 +1335,12 @@ namespace Algolia.Search
         /// Search/Browse all synonyms
         /// </summary>
         /// <param name="query">The query string</param>
+        /// <param name="requestOptions"></param>
         /// <param name="types">Specify the types</param>
         /// <param name="page">The page to fetch</param>
         /// <param name="hitsPerPage">number of synonyms to fetch</param>
-        public Task<JObject> SearchSynonymsAsync(string query, IEnumerable<SynonymType> types = null, int? page = null, int? hitsPerPage = null, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        /// <param name="token"></param>
+        public Task<JObject> SearchSynonymsAsync(string query, RequestOptions requestOptions, IEnumerable<SynonymType> types = null, int? page = null, int? hitsPerPage = null, CancellationToken token = default(CancellationToken))
         {
             string[] typesStr = null;
             if (types != null)
@@ -1276,27 +1351,32 @@ namespace Algolia.Search
                     typesStr[i] = SynonymsTypeToString(types.ElementAt(i));
                 }
             }
-            return SearchSynonymsAsync(query, typesStr, page, hitsPerPage, token, requestOptions);
+            return SearchSynonymsAsync(query, requestOptions, typesStr, page, hitsPerPage, token);
         }
+
         /// <summary>
         /// Synchronously call <see cref="Index.SearchSynonymsAsync"/>.
         /// </summary>
         /// <param name="query">The query string</param>
+        /// <param name="requestOptions"></param>
         /// <param name="types">Specify the types</param>
         /// <param name="page">The page to fetch</param>
         /// <param name="hitsPerPage">number of synonyms to fetch</param>
-        public JObject SearchSynonyms(string query, IEnumerable<SynonymType> types = null, int? page = null, int? hitsPerPage = null, RequestOptions requestOptions = null)
+        public JObject SearchSynonyms(string query, RequestOptions requestOptions, IEnumerable<SynonymType> types = null, int? page = null, int? hitsPerPage = null)
         {
-            return SearchSynonymsAsync(query, types, page, hitsPerPage, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return SearchSynonymsAsync(query, requestOptions, types, page, hitsPerPage, default(CancellationToken)).GetAwaiter().GetResult();
         }
+
         /// <summary>
         /// Search/Browse all synonyms
         /// </summary>
         /// <param name="query">The query string</param>
+        /// <param name="requestOptions"></param>
         /// <param name="types">Specify the types</param>
         /// <param name="page">The page to fetch</param>
         /// <param name="hitsPerPage">number of synonyms to fetch</param>
-        public Task<JObject> SearchSynonymsAsync(string query, IEnumerable<string> types = null, int? page = null, int? hitsPerPage = null, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        /// <param name="token"></param>
+        public Task<JObject> SearchSynonymsAsync(string query, RequestOptions requestOptions, IEnumerable<string> types = null, int? page = null, int? hitsPerPage = null, CancellationToken token = default(CancellationToken))
         {
             Dictionary<string, object> body = new Dictionary<string, object>();
             body["query"] = query;
@@ -1317,19 +1397,22 @@ namespace Algolia.Search
         /// Synchronously call <see cref="Index.SearchSynonymsAsync"/>.
         /// </summary>
         /// <param name="query">The query string</param>
+        /// <param name="requestOptions"></param>
         /// <param name="types">Specify the types</param>
         /// <param name="page">The page to fetch</param>
         /// <param name="hitsPerPage">number of synonyms to fetch</param>
-        public JObject SearchSynonyms(string query, IEnumerable<string> types = null, int? page = null, int? hitsPerPage = null, RequestOptions requestOptions = null)
+        public JObject SearchSynonyms(string query, RequestOptions requestOptions, IEnumerable<string> types = null, int? page = null, int? hitsPerPage = null)
         {
-            return SearchSynonymsAsync(query, types, page, hitsPerPage, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return SearchSynonymsAsync(query, requestOptions, types, page, hitsPerPage, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Get one synonym
         /// </summary>
         /// <param name="objectID">The objectID of the synonym</param>
-        public Task<JObject> GetSynonymAsync(string objectID, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        /// <param name="requestOptions"></param>
+        /// <param name="token"></param>
+        public Task<JObject> GetSynonymAsync(string objectID, RequestOptions requestOptions, CancellationToken token = default(CancellationToken))
         {
             return _client.ExecuteRequest(AlgoliaClient.callType.Read, "GET", string.Format("/1/indexes/{0}/synonyms/{1}", _urlIndexName, WebUtility.UrlEncode(objectID)), null, token, requestOptions);
         }
@@ -1338,17 +1421,20 @@ namespace Algolia.Search
         /// Synchronously call <see cref="Index.GetSynonymAsync"/>.
         /// </summary>
         /// <param name="objectID">The objectID of the synonym</param>
-        public JObject GetSynonym(string objectID, RequestOptions requestOptions = null)
+        /// <param name="requestOptions"></param>
+        public JObject GetSynonym(string objectID, RequestOptions requestOptions)
         {
-            return GetSynonymAsync(objectID, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return GetSynonymAsync(objectID, requestOptions, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Delete one synonym
         /// </summary>
         /// <param name="objectID">The objectID of the synonym</param>
+        /// <param name="requestOptions"></param>
         /// <param name="forwardToReplicas">Forward the operation to the replica indices</param>
-        public Task<JObject> DeleteSynonymAsync(string objectID, bool forwardToReplicas = false, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        /// <param name="token"></param>
+        public Task<JObject> DeleteSynonymAsync(string objectID, RequestOptions requestOptions, bool forwardToReplicas = false, CancellationToken token = default(CancellationToken))
         {
             return _client.ExecuteRequest(AlgoliaClient.callType.Write, "DELETE", string.Format("/1/indexes/{0}/synonyms/{1}?forwardToReplicas={2}", _urlIndexName, WebUtility.UrlEncode(objectID), forwardToReplicas ? "true" : "false"), null, token, requestOptions);
         }
@@ -1357,17 +1443,20 @@ namespace Algolia.Search
         /// Synchronously call <see cref="Index.DeleteSynonymAsync"/>.
         /// </summary>
         /// <param name="objectID">The objectID of the synonym</param>
+        /// <param name="requestOptions"></param>
         /// <param name="forwardToReplicas">Forward the operation to the replica indices</param>
-        public JObject DeleteSynonym(string objectID, bool forwardToReplicas = false, RequestOptions requestOptions = null)
+        public JObject DeleteSynonym(string objectID, RequestOptions requestOptions, bool forwardToReplicas = false)
         {
-            return DeleteSynonymAsync(objectID, forwardToReplicas, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return DeleteSynonymAsync(objectID, requestOptions, forwardToReplicas, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Delete all synonym set
         /// </summary>
+        /// <param name="requestOptions"></param>
         /// <param name="forwardToReplicas">Forward the operation to the replica indices</param>
-        public Task<JObject> ClearSynonymsAsync(bool forwardToReplicas = false, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        /// <param name="token"></param>
+        public Task<JObject> ClearSynonymsAsync(RequestOptions requestOptions, bool forwardToReplicas = false, CancellationToken token = default(CancellationToken))
         {
             return _client.ExecuteRequest(AlgoliaClient.callType.Write, "POST", string.Format("/1/indexes/{0}/synonyms/clear?forwardToReplicas={1}", _urlIndexName, forwardToReplicas ? "true" : "false"), null, token, requestOptions);
         }
@@ -1375,18 +1464,22 @@ namespace Algolia.Search
         /// <summary>
         /// Synchronously call <see cref="Index.BrowseFromAsync"/>.
         /// </summary>
+        /// <param name="requestOptions"></param>
         /// <param name="forwardToReplicas">Forward the operation to the replica indices</param>
-        public JObject ClearSynonyms(bool forwardToReplicas = false, RequestOptions requestOptions = null)
+        public JObject ClearSynonyms(RequestOptions requestOptions, bool forwardToReplicas = false)
         {
-            return ClearSynonymsAsync(forwardToReplicas, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return ClearSynonymsAsync(requestOptions, forwardToReplicas, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Add or Replace a list of synonyms 
         /// </summary>
+        /// <param name="objects"></param>
+        /// <param name="requestOptions"></param>
         /// <param name="forwardToReplicas">Forward the operation to the replica indices</param>
         /// <param name="replaceExistingSynonyms">Replace the existing synonyms with this batch</param>
-        public Task<JObject> BatchSynonymsAsync(IEnumerable<object> objects, bool forwardToReplicas = false, bool replaceExistingSynonyms = false, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        /// <param name="token"></param>
+        public Task<JObject> BatchSynonymsAsync(IEnumerable<object> objects, RequestOptions requestOptions, bool forwardToReplicas = false, bool replaceExistingSynonyms = false, CancellationToken token = default(CancellationToken))
         {
             return _client.ExecuteRequest(AlgoliaClient.callType.Write, "POST", string.Format("/1/indexes/{0}/synonyms/batch?replaceExistingSynonyms={1}&forwardToReplicas={2}", _urlIndexName, replaceExistingSynonyms ? "true" : "false", forwardToReplicas ? "true" : "false"), objects, token, requestOptions);
         }
@@ -1394,11 +1487,13 @@ namespace Algolia.Search
         /// <summary>
         /// Synchronously call <see cref="Index.BatchSynonymsAsync"/>.
         /// </summary>
+        /// <param name="objects"></param>
+        /// <param name="requestOptions"></param>
         /// <param name="forwardToReplicas">Forward the operation to the replica indices</param>
         /// <param name="replaceExistingSynonyms">Replace the existing synonyms with this batch</param>
-        public JObject BatchSynonyms(IEnumerable<object> objects, bool forwardToReplicas = false, bool replaceExistingSynonyms = false, RequestOptions requestOptions = null)
+        public JObject BatchSynonyms(IEnumerable<object> objects, RequestOptions requestOptions, bool forwardToReplicas = false, bool replaceExistingSynonyms = false)
         {
-            return BatchSynonymsAsync(objects, forwardToReplicas, replaceExistingSynonyms, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return BatchSynonymsAsync(objects, requestOptions, forwardToReplicas, replaceExistingSynonyms, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -1406,8 +1501,10 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="objectID">The objectID of the synonym</param>
         /// <param name="content">The new content of this synonym</param>
+        /// <param name="requestOptions"></param>
         /// <param name="forwardToReplicas">Forward the operation to the replica indices</param>
-        public Task<JObject> SaveSynonymAsync(string objectID, object content, bool forwardToReplicas = false, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        /// <param name="token"></param>
+        public Task<JObject> SaveSynonymAsync(string objectID, object content, RequestOptions requestOptions, bool forwardToReplicas = false, CancellationToken token = default(CancellationToken))
         {
             return _client.ExecuteRequest(AlgoliaClient.callType.Write, "PUT", string.Format("/1/indexes/{0}/synonyms/{1}?forwardToReplicas={2}", _urlIndexName,  WebUtility.UrlEncode(objectID), forwardToReplicas ? "true" : "false"), content, token, requestOptions);
         }
@@ -1415,10 +1512,14 @@ namespace Algolia.Search
         /// <summary>
         /// Synchronously call <see cref="Index.SaveSynonymAsync"/>.
         /// </summary>
+        /// <param name="objectID"></param>
+        /// <param name="content"></param>
+        /// <param name="requestOptions"></param>
         /// <param name="forwardToReplicas">Forward the operation to the replica indices</param>
-        public JObject SaveSynonym(string objectID, object content, bool forwardToReplicas = false, bool replaceExistingSynonyms = false, RequestOptions requestOptions = null)
+        /// <param name="replaceExistingSynonyms"></param>
+        public JObject SaveSynonym(string objectID, object content, RequestOptions requestOptions, bool forwardToReplicas = false, bool replaceExistingSynonyms = false)
         {
-            return SaveSynonymAsync(objectID, content, forwardToReplicas, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return SaveSynonymAsync(objectID, content, requestOptions, forwardToReplicas, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -1426,21 +1527,23 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="facetName">Name of the facet</param>
         /// <param name="facetQuery">Current query</param>
+        /// <param name="requestOptions"></param>
         /// <param name="queryParams">Optional query parameter</param>
-        public JObject SearchForFacetValues(string facetName, string facetQuery, Query queryParams = null, RequestOptions requestOptions = null)
+        public JObject SearchForFacetValues(string facetName, string facetQuery, RequestOptions requestOptions, Query queryParams = null)
         {
-            return SearchForFacetValuesAsync(facetName, facetQuery, queryParams, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return SearchForFacetValuesAsync(facetName, facetQuery, requestOptions, queryParams, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
-        /// <summary>
-        ///= kept for backward compatibility - Synchronously call <see cref="Index.SearchFacetAsync"/>.
-        /// </summary>
+        ///  <summary>
+        /// = kept for backward compatibility - Synchronously call <see cref="Index.SearchFacetAsync"/>.
+        ///  </summary>
         /// <param name="facetName">Name of the facet</param>
         /// <param name="facetQuery">Current query</param>
+        /// <param name="requestOptions"></param>
         /// <param name="queryParams">Optional query parameter</param>
-        public JObject SearchFacet(string facetName, string facetQuery, Query queryParams = null, RequestOptions requestOptions = null)
+        public JObject SearchFacet(string facetName, string facetQuery, RequestOptions requestOptions, Query queryParams = null)
         {
-            return SearchFacetAsync(facetName, facetQuery, queryParams, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return SearchFacetAsync(facetName, facetQuery, requestOptions, queryParams, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -1448,8 +1551,10 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="facetName">Name of the facet</param>
         /// <param name="facetQuery">Current Query</param>
+        /// <param name="requestOptions"></param>
         /// <param name="queryParams">Optional query parameter</param>
-        public Task<JObject> SearchFacetAsync(string facetName, string facetQuery, Query queryParams = null, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        /// <param name="token"></param>
+        public Task<JObject> SearchFacetAsync(string facetName, string facetQuery, RequestOptions requestOptions, Query queryParams = null, CancellationToken token = default(CancellationToken))
         {
             if(queryParams == null)
             {
@@ -1467,8 +1572,10 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="facetName">Name of the facet</param>
         /// <param name="facetQuery">Current Query</param>
+        /// <param name="requestOptions"></param>
         /// <param name="queryParams">Optional query parameter</param>
-        public Task<JObject> SearchForFacetValuesAsync(string facetName, string facetQuery, Query queryParams = null, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        /// <param name="token"></param>
+        public Task<JObject> SearchForFacetValuesAsync(string facetName, string facetQuery, RequestOptions requestOptions, Query queryParams = null, CancellationToken token = default(CancellationToken))
         {
             if (queryParams == null)
             {
@@ -1485,8 +1592,10 @@ namespace Algolia.Search
         ///  Save a new rule in the index.
         /// </summary>
         /// <param name="queryRule">The body of the rule to save (must contain an objectID attribute).</param>
+        /// <param name="requestOptions"></param>
         /// <param name="forwardToReplicas">whether to forward to replicas or not (defaults to false)</param>
-        public Task<JObject> SaveRuleAsync(JObject queryRule, bool forwardToReplicas = false, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        /// <param name="token"></param>
+        public Task<JObject> SaveRuleAsync(JObject queryRule, RequestOptions requestOptions, bool forwardToReplicas = false, CancellationToken token = default(CancellationToken))
         {
             if (queryRule["objectID"] == null)
             {
@@ -1501,17 +1610,20 @@ namespace Algolia.Search
         /// Synchronously call <see cref="Index.SaveRuleAsync"/>.
         /// </summary>
         /// <param name="queryRule">The object to save (must contain an objectID attribute).</param>
+        /// <param name="requestOptions"></param>
         /// <param name="forwardToReplicas">whether to forward to replicas or not (defaults to false)</param>
-        public JObject SaveRule(JObject queryRule, bool forwardToReplicas = false, RequestOptions requestOptions = null)
+        public JObject SaveRule(JObject queryRule, RequestOptions requestOptions, bool forwardToReplicas = false)
         {
-            return SaveRuleAsync(queryRule,forwardToReplicas,default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return SaveRuleAsync(queryRule, requestOptions, forwardToReplicas,default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
         ///  Retrieve a rule from the index with the specified objectID.
         /// </summary>
         /// <param name="objectID">The objectID of the rule to retrieve.</param>
-        public Task<JObject> GetRuleAsync(string objectID, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        /// <param name="requestOptions"></param>
+        /// <param name="token"></param>
+        public Task<JObject> GetRuleAsync(string objectID, RequestOptions requestOptions, CancellationToken token = default(CancellationToken))
         {
             if (string.IsNullOrEmpty(objectID))
             {
@@ -1525,16 +1637,19 @@ namespace Algolia.Search
         /// Synchronously call <see cref="Index.GetRuleAsync"/>.
         /// </summary>
         /// <param name="objectID">The objectID of the rule to retrieve.</param>
-        public JObject GetRule(string objectID, RequestOptions requestOptions = null)
+        /// <param name="requestOptions"></param>
+        public JObject GetRule(string objectID, RequestOptions requestOptions)
         {
-            return GetRuleAsync(objectID, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return GetRuleAsync(objectID, requestOptions, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
         ///  Search for rules inside the index.
         /// </summary>
+        /// <param name="requestOptions"></param>
         /// <param name="query">the query rules</param>
-        public Task<JObject> SearchRulesAsync(RuleQuery query = null, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        /// <param name="token"></param>
+        public Task<JObject> SearchRulesAsync(RequestOptions requestOptions, RuleQuery query = null, CancellationToken token = default(CancellationToken))
         {
             return _client.ExecuteRequest(AlgoliaClient.callType.Write, "POST", string.Format("/1/indexes/{0}/rules/search", _urlIndexName), query, token, requestOptions);
         }
@@ -1542,18 +1657,21 @@ namespace Algolia.Search
         /// <summary>
         /// Synchronously call <see cref="Index.SearchRulesAsync"/>.
         /// </summary>
+        /// <param name="requestOptions"></param>
         /// <param name="query">the query rules</param>
-        public JObject SearchRules(RuleQuery query = null, RequestOptions requestOptions = null)
+        public JObject SearchRules(RequestOptions requestOptions, RuleQuery query = null)
         {
-	        return SearchRulesAsync(query, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+	        return SearchRulesAsync(requestOptions, query, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
         ///  Delete a rule from the index with the specified objectID.
         /// </summary>
         /// <param name="objectID">The objectID of the rule to retrieve.</param>
+        /// <param name="requestOptions"></param>
         /// <param name="forwardToReplicas">whether to forward to replicas or not (defaults to false)</param>
-        public Task<JObject> DeleteRuleAsync(string objectID, bool forwardToReplicas = false, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        /// <param name="token"></param>
+        public Task<JObject> DeleteRuleAsync(string objectID, RequestOptions requestOptions, bool forwardToReplicas = false, CancellationToken token = default(CancellationToken))
         {
             if (string.IsNullOrEmpty(objectID))
             {
@@ -1567,17 +1685,20 @@ namespace Algolia.Search
         /// Synchronously call <see cref="Index.DeleteRuleAsync"/>.
         /// </summary>
         /// <param name="objectID">The objectID of the rule to retrieve.</param>
+        /// <param name="requestOptions"></param>
         /// <param name="forwardToReplicas">whether to forward to replicas or not (defaults to false)</param>
-        public JObject DeleteRule(string objectID, bool forwardToReplicas = false, RequestOptions requestOptions = null)
+        public JObject DeleteRule(string objectID, RequestOptions requestOptions, bool forwardToReplicas = false)
         {
-            return DeleteRuleAsync(objectID, forwardToReplicas, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return DeleteRuleAsync(objectID, requestOptions, forwardToReplicas, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Clear all the rules of an index.
         /// </summary>
+        /// <param name="requestOptions"></param>
         /// <param name="forwardToReplicas">whether to forward to replicas or not (defaults to false)</param>
-        public Task<JObject> ClearRulesAsync(bool forwardToReplicas = false, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        /// <param name="token"></param>
+        public Task<JObject> ClearRulesAsync(RequestOptions requestOptions, bool forwardToReplicas = false, CancellationToken token = default(CancellationToken))
         {
             return _client.ExecuteRequest(AlgoliaClient.callType.Write, "POST", string.Format("/1/indexes/{0}/rules/clear?forwardToReplicas={1}", _urlIndexName, forwardToReplicas.ToString().ToLower()), null, token, requestOptions);
         }
@@ -1585,10 +1706,11 @@ namespace Algolia.Search
         /// <summary>
         /// Synchronously call <see cref="Index.ClearRulesAsync"/>.
         /// </summary>
+        /// <param name="requestOptions"></param>
         /// <param name="forwardToReplicas">whether to forward to replicas or not (defaults to false)</param>
-        public JObject ClearRules(bool forwardToReplicas = false, RequestOptions requestOptions = null)
+        public JObject ClearRules(RequestOptions requestOptions, bool forwardToReplicas = false)
         {
-            return ClearRulesAsync(forwardToReplicas, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return ClearRulesAsync(requestOptions, forwardToReplicas, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -1597,7 +1719,7 @@ namespace Algolia.Search
         /// <param name="queryRules">Batch of rules to be added to the index (must contain an objectID attribute).</param>
         /// <param name="forwardToReplicas">whether to forward to replicas or not (defaults to false)</param>
         /// <param name="clearExistingRules">whether to clear existing rules in the index or not (defaults to false)</param>
-        public Task<JObject> BatchRulesAsync(IEnumerable<JObject> queryRules, bool forwardToReplicas = false, bool clearExistingRules = false, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
+        public Task<JObject> BatchRulesAsync(IEnumerable<JObject> queryRules, RequestOptions requestOptions, bool forwardToReplicas = false, bool clearExistingRules = false, CancellationToken token = default(CancellationToken))
         {
             return _client.ExecuteRequest(AlgoliaClient.callType.Write, "POST", string.Format("/1/indexes/{0}/rules/batch?forwardToReplicas={1}&clearExistingRules={2}", _urlIndexName, forwardToReplicas.ToString().ToLower(), clearExistingRules.ToString().ToLower()), queryRules, token, requestOptions);
         }
@@ -1606,11 +1728,927 @@ namespace Algolia.Search
         /// Synchronously call <see cref="Index.BatchRulesAsync"/>.
         /// </summary>
         /// <param name="queryRules">The object to save (must contain an objectID attribute).</param>
+        /// <param name="requestOptions"></param>
         /// <param name="forwardToReplicas">whether to forward to replicas or not (defaults to false)</param>
         /// <param name="clearExistingRules">whether to clear existing rules in the index or not (defaults to false)</param>
-        public JObject BatchRules(IEnumerable<JObject> queryRules, bool forwardToReplicas = false, bool clearExistingRules = false, RequestOptions requestOptions = null)
+        public JObject BatchRules(IEnumerable<JObject> queryRules, RequestOptions requestOptions, bool forwardToReplicas = false, bool clearExistingRules = false)
         {
-            return BatchRulesAsync(queryRules, forwardToReplicas, clearExistingRules, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
+            return BatchRulesAsync(queryRules, requestOptions, forwardToReplicas, clearExistingRules, default(CancellationToken)).GetAwaiter().GetResult();
         }
+
+        /* 
+         * These are overloaded methods of everything above in order to avoid binary incompatibility 
+         * when adding all the requestOptions parameters
+         */
+
+        /// <summary>
+        /// Add an object to this index.
+        /// </summary>
+        /// <param name="content">The object you want to add to the index.</param>
+        /// <param name="objectId">Optional objectID you want to attribute to this object (if the attribute already exists the old object will be overwritten).</param>
+        /// <param name="token"></param>
+        /// <returns>An object that contains an "objectID" attribute.</returns>
+        public Task<JObject> AddObjectAsync(object content, string objectId = null, CancellationToken token = default(CancellationToken))
+        { return AddObjectAsync(content, null, objectId, token); }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.AddObjectAsync"/>.
+        /// </summary>
+        /// <param name="content">The object you want to add to the index.</param>
+
+        /// <param name="objectId">Optional objectID you want to attribute to this object (if the attribute already exists the old object will be overwritten).</param>
+        /// <returns>An object that contains an "objectID" attribute.</returns>
+        public JObject AddObject(object content, string objectId = null)
+        { return AddObject(content, null, objectId); }
+
+        /// <summary>
+        /// Add several objects to this index.
+        /// </summary>
+        /// <param name="objects">An array of objects to add. If the objects contains objectIDs, they will be used.</param>
+        /// <param name="token"></param>
+        /// <returns>An object containing an "objectIDs" attribute (array of string).</returns>
+        public Task<JObject> AddObjectsAsync(IEnumerable<object> objects, CancellationToken token = default(CancellationToken))
+        { return AddObjectsAsync(objects, null, token); }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.AddObjectsAsync"/>.
+        /// </summary>
+        /// <param name="objects">An array of objects to add. If the objects contains objectIDs, they will be used.</param>
+        /// <returns>An object containing an "objectIDs" attribute (array of string).</returns>
+        public JObject AddObjects(IEnumerable<object> objects)
+        { return AddObjects(objects, null); }
+
+        /// <summary>
+        /// Get an object from this index.
+        /// </summary>
+        /// <param name="objectID">The unique identifier of the object to retrieve.</param>
+        /// <param name="attributesToRetrieve">Optional list of attributes to retrieve.</param>
+        /// <param name="token"></param>
+        /// <returns></returns>
+        public Task<JObject> GetObjectAsync(string objectID, IEnumerable<string> attributesToRetrieve = null, CancellationToken token = default(CancellationToken))
+        { return GetObjectAsync(objectID, null, attributesToRetrieve, token); }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.GetObjectAsync"/>.
+        /// </summary>
+        /// <param name="objectID">The unique identifier of the object to retrieve.</param>
+        /// <param name="attributesToRetrieve">Optional list of attributes to retrieve.</param>
+        /// <returns></returns>
+        public JObject GetObject(string objectID, IEnumerable<string> attributesToRetrieve = null)
+        { return GetObject(objectID, null, attributesToRetrieve); }
+
+        /// <summary>
+        /// Get several objects from this index.
+        /// </summary>
+        /// <param name="objectIDs">An array of unique identifiers of the objects to retrieve.</param>
+        /// <param name="token"></param>
+        /// <returns></returns> 
+        public Task<JObject> GetObjectsAsync(IEnumerable<string> objectIDs, CancellationToken token = default(CancellationToken))
+        { return GetObjectsAsync(objectIDs, (RequestOptions) null, token); }
+
+        /// <summary>
+        /// Get several objects from this index.
+        /// </summary>
+        /// <param name="objectIDs">An array of unique identifiers of the objects to retrieve.</param>
+        /// <param name="attributesToRetrieve"></param>
+        /// <param name="token"></param>
+        /// <returns></returns> 
+        public Task<JObject> GetObjectsAsync(IEnumerable<string> objectIDs, IEnumerable<string> attributesToRetrieve, CancellationToken token = default(CancellationToken))
+        { return GetObjectsAsync(objectIDs, attributesToRetrieve, null, token); }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.GetObjectsAsync"/>.
+        /// </summary>
+        /// <param name="objectIDs">An array of unique identifiers of the objects to retrieve.</param>
+        /// <returns></returns> 
+        public JObject GetObjects(IEnumerable<string> objectIDs)
+        { return GetObjects(objectIDs, (RequestOptions) null); }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.GetObjectsWithAttributesAsync"/>.
+        /// </summary>
+        /// <param name="objectIDs">An array of unique identifiers of the objects to retrieve.</param>
+        /// <param name="attributesToRetrieve">list of attributes to retrieve.</param>
+        /// <returns></returns> 
+        public JObject GetObjects(IEnumerable<string> objectIDs, IEnumerable<string> attributesToRetrieve)
+        { return GetObjects(objectIDs, attributesToRetrieve, null); }
+
+        /// <summary>
+        /// Partially update an object (only update attributes passed in argument).
+        /// </summary>
+        /// <param name="partialObject">The object attributes to override (must contains an objectID attribute).</param>
+        /// <param name="createIfNotExists"></param>
+        /// <param name="token"></param>
+        /// <returns>An object containing an "updatedAt" attribute.</returns>
+        public Task<JObject> PartialUpdateObjectAsync(JObject partialObject, bool createIfNotExists = true, CancellationToken token = default(CancellationToken))
+        { return PartialUpdateObjectAsync(partialObject, null, createIfNotExists, token); }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.PartialUpdateObjectAsync"/>.
+        /// </summary>
+        /// <param name="partialObject">The object attributes to override (must contains an objectID attribute).</param>
+        /// <param name="createIfNotExists"></param>
+        /// <returns>An object containing an "updatedAt" attribute.</returns>
+        public JObject PartialUpdateObject(JObject partialObject, bool createIfNotExists = true)
+        { return PartialUpdateObject(partialObject, null, createIfNotExists); }
+
+        /// <summary>
+        /// Partially update the content of several objects.
+        /// </summary>
+        /// <param name="objects">An array of objects to update (each object must contain an objectID attribute).</param>
+        /// <param name="createIfNotExists"></param>
+        /// <param name="token"></param>
+        /// <returns>An object containing an "objectIDs" attribute (array of string).</returns>
+        public Task<JObject> PartialUpdateObjectsAsync(IEnumerable<JObject> objects, bool createIfNotExists = true, CancellationToken token = default(CancellationToken))
+        { return PartialUpdateObjectsAsync(objects, null, createIfNotExists, token); }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.PartialUpdateObjectsAsync"/>.
+        /// </summary>
+        /// <param name="objects">An array of objects to update (each object must contain an objectID attribute).</param>
+        /// <param name="createIfNotExists"></param>
+        /// <returns>An object containing an "objectIDs" attribute (array of string).</returns>
+        public JObject PartialUpdateObjects(IEnumerable<JObject> objects, bool createIfNotExists = true)
+        { return PartialUpdateObjects(objects, null, createIfNotExists); }
+
+        /// <summary>
+        /// Override the contents of an object.
+        /// </summary>
+        /// <param name="obj">The object to save (must contain an objectID attribute).</param>
+        /// <param name="token"></param>
+        /// <returns>An object containing an "updatedAt" attribute.</returns>
+        public Task<JObject> SaveObjectAsync(JObject obj, CancellationToken token = default(CancellationToken))
+        { return SaveObjectAsync(obj, null, token); }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.SaveObjectAsync"/>.
+        /// </summary>
+        /// <param name="obj">The object to save (must contain an objectID attribute).</param>
+        /// <returns>An object containing an "updatedAt" attribute.</returns>
+        public JObject SaveObject(JObject obj)
+        { return SaveObject(obj, null); }
+
+        /// <summary>
+        /// Override the contents of several objects.
+        /// </summary>
+        /// <param name="objects">An array of objects to update (each object must contain an objectID attribute).</param>
+        /// <param name="token"></param>
+        /// <returns>An object containing an "objectIDs" attribute (array of string).</returns>
+        public Task<JObject> SaveObjectsAsync(IEnumerable<JObject> objects, CancellationToken token = default(CancellationToken))
+        { return SaveObjectsAsync(objects, null, token); }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.SaveObjectsAsync"/>.
+        /// </summary>
+        /// <param name="objects">An array of objects to update (each object must contain an objectID attribute).</param>
+        /// <returns>An object containing an "objectIDs" attribute (array of string).</returns>
+        public JObject SaveObjects(IEnumerable<JObject> objects)
+        { return SaveObjects(objects, null); }
+
+        /// <summary>
+        /// Delete an object from the index.
+        /// </summary>
+        /// <param name="objectID">The unique identifier of the object to delete.</param>
+        /// <param name="token"></param>
+        /// <returns>An object containing a "deletedAt" attribute.</returns>
+        public Task<JObject> DeleteObjectAsync(string objectID, CancellationToken token = default(CancellationToken))
+        { return DeleteObjectAsync(objectID, null, token); }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.DeleteObjectAsync"/>.
+        /// </summary>
+        /// <param name="objectID">The unique identifier of the object to delete.</param>
+        /// <returns>An object containing a "deletedAt" attribute.</returns>
+        public JObject DeleteObject(string objectID)
+        { return DeleteObject(objectID, null); }
+
+        /// <summary>
+        /// Delete several objects.
+        /// </summary>
+        /// <param name="objects">An array of objectIDs to delete.</param>
+        /// <param name="token"></param>
+        public Task<JObject> DeleteObjectsAsync(IEnumerable<string> objects, CancellationToken token = default(CancellationToken))
+        { return DeleteObjectsAsync(objects, null, token); }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.DeleteObjectsAsync"/>.
+        /// </summary>
+        /// <param name="objects">An array of objectIDs to delete.</param>
+        public JObject DeleteObjects(IEnumerable<string> objects)
+        { return DeleteObjects(objects, null); }
+
+        /// <summary>
+        /// Delete all objects matching a query.
+        /// </summary>
+        /// <param name="query">The query.</param>
+        async public Task DeleteByQueryAsync(Query query)
+        { await DeleteByQueryAsync(query, (RequestOptions) null); }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.DeleteByQueryAsync"/>.
+        /// </summary>
+        /// <param name="query">The query.</param>
+        public void DeleteByQuery(Query query)
+        { DeleteByQuery(query, null); }
+
+        /// <summary>
+        /// Search inside the index.
+        /// </summary>
+        /// <param name="q">The query.</param>
+        /// <param name="token"></param>
+        public Task<JObject> SearchAsync(Query q, CancellationToken token = default(CancellationToken))
+        { return SearchAsync(q, null, token); }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.SearchAsync"/>.
+        /// </summary>
+        /// <param name="q">The query.</param>
+        public JObject Search(Query q)
+        { return Search(q, null); }
+
+        /// <summary>
+        /// Check to see if the asynchronous server task is complete.
+        /// </summary>
+        /// <param name="taskID">The id of the task returned by server.</param>
+        /// <param name="timeToWait"></param>
+        /// <param name="token"></param>
+        async public Task WaitTaskAsync(string taskID, int timeToWait = 100, CancellationToken token = default(CancellationToken))
+        { await WaitTaskAsync(taskID, null, timeToWait, token); }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.WaitTaskAsync"/>.
+        /// </summary>
+        /// <param name="taskID">The id of the task returned by server.</param>
+        /// <param name="timeToWait"></param>
+        public void WaitTask(string taskID, int timeToWait = 100)
+        { WaitTask(taskID, null, timeToWait); }
+
+        /// <summary>
+        /// Get the index settings.
+        /// </summary>
+        /// <returns>An object containing the settings.</returns>
+        public Task<JObject> GetSettingsAsync(CancellationToken token = default(CancellationToken))
+        { return GetSettingsAsync(null, token); }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.GetSettingsAsync"/>.
+        /// </summary>
+        /// <returns>An object containing the settings.</returns>
+        public JObject GetSettings()
+        { return GetSettings(null); }
+
+        /// <summary>
+        ///  Browse all index contents.
+        /// </summary>
+        /// <param name="page">The page number to browse.</param>
+        /// <param name="hitsPerPage">The number of hits per page.</param>
+        /// <param name="token"></param>
+        public Task<JObject> BrowseAsync(int page = 0, int hitsPerPage = 1000, CancellationToken token = default(CancellationToken))
+        { return BrowseAsync(null, page, hitsPerPage, token); }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.BrowseAsync"/>.
+        /// </summary>
+        /// <param name="page">The page number to browse.</param>
+        /// <param name="hitsPerPage">The number of hits per page.</param>
+        public JObject Browse(int page = 0, int hitsPerPage = 1000)
+        { return Browse(null, page, hitsPerPage); }
+
+        /// <summary>
+        ///  Browse all index contents.
+        /// </summary>
+        /// <param name="q">The query parameters for the browse.</param>
+        /// <param name="cursor">The cursor to start the browse can be empty.</param>
+        /// <param name="token"></param>
+        public Task<JObject> BrowseFromAsync(Query q, string cursor, CancellationToken token = default(CancellationToken))
+        { return BrowseFromAsync(q, cursor, null, token); }
+
+        /// <summary>
+        /// Delete the index contents without removing settings and index specific API keys.
+        /// </summary>
+        public Task<JObject> ClearIndexAsync(CancellationToken token = default(CancellationToken))
+        { return ClearIndexAsync(null, token); }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.ClearIndexAsync"/>.
+        /// </summary>
+        public JObject ClearIndex()
+        {
+            return ClearIndex(null);
+        }
+
+        /// <summary>
+        /// Set the settings for this index.
+        /// </summary>
+        /// <param name="settings">The settings object can contain:
+        ///     - minWordSizefor1Typo: (integer) the minimum number of characters to accept one typo (default = 3).
+        ///     - minWordSizefor2Typos: (integer) the minimum number of characters to accept two typos (default = 7).
+        ///     - hitsPerPage: (integer) the number of hits per page (default = 10).
+        ///     - attributesToRetrieve: (array of strings) default list of attributes to retrieve in objects. 
+        ///     If set to null, all attributes are retrieved.
+        ///     - attributesToHighlight: (array of strings) default list of attributes to highlight. 
+        ///     If set to null, all indexed attributes are highlighted.
+        ///     - attributesToSnippet**: (array of strings) default list of attributes to snippet alongside the number of words to return (syntax is attributeName:nbWords).
+        ///     By default no snippet is computed. If set to null, no snippet is computed.
+        ///     - searchableAttributes(formerly attributesToIndex): (array of strings) the list of fields you want to index.
+        ///     If set to null, all textual and numerical attributes of your objects are indexed, but you should update it to get optimal results.
+        ///     This parameter has two important uses:
+        ///     - Limit the attributes to index: For example if you store a binary image in base64, you want to store it and be able to 
+        ///     retrieve it but you don't want to search in the base64 string.
+        ///     - Control part of the ranking*: (see the ranking parameter for full explanation) Matches in attributes at the beginning of 
+        ///     the list will be considered more important than matches in attributes further down the list. 
+        ///     In one attribute, matching text at the beginning of the attribute will be considered more important than text after, you can disable 
+        ///     this behavior if you add your attribute inside `unordered(AttributeName)`, for example searchableAttributes: ["title", "unordered(text)"].
+        ///     - attributesForFaceting: (array of strings) The list of fields you want to use for faceting. 
+        ///     All strings in the attribute selected for faceting are extracted and added as a facet. If set to null, no attribute is used for faceting.
+        ///     - ranking: (array of strings) controls the way results are sorted.
+        ///     We have six available criteria: 
+        ///     - typo: sort according to number of typos,
+        ///     - geo: sort according to decreassing distance when performing a geo-location based search,
+        ///     - proximity: sort according to the proximity of query words in hits,
+        ///     - attribute: sort according to the order of attributes defined by searchableAttributes,
+        ///     - exact: sort according to the number of words that are matched identical to query word (and not as a prefix),
+        ///     - custom: sort according to a user defined formula set in **customRanking** attribute.
+        ///     The standard order is ["typo", "geo", "proximity", "attribute", "exact", "custom"]
+        ///     - customRanking: (array of strings) lets you specify part of the ranking.
+        ///     The syntax of this condition is an array of strings containing attributes prefixed by asc (ascending order) or desc (descending order) operator.
+        ///     For example `"customRanking" => ["desc(population)", "asc(name)"]`  
+        ///     - queryType: Select how the query words are interpreted, it can be one of the following value:
+        ///     - prefixAll: all query words are interpreted as prefixes,
+        ///     - prefixLast: only the last word is interpreted as a prefix (default behavior),
+        ///     - prefixNone: no query word is interpreted as a prefix. This option is not recommended.
+        ///     - highlightPreTag: (string) Specify the string that is inserted before the highlighted parts in the query result (default to "<em>").
+        ///         - highlightPostTag: (string) Specify the string that is inserted after the highlighted parts in the query result (default to "</em>").
+        ///     - optionalWords: (array of strings) Specify a list of words that should be considered as optional when found in the query.
+        /// </param>
+        /// <param name="forwardToReplicas">Forward the operation to the replica indices</param>
+        /// <param name="token"></param>
+        public Task<JObject> SetSettingsAsync(JObject settings, bool forwardToReplicas = false, CancellationToken token = default(CancellationToken))
+        { return SetSettingsAsync(settings, null, forwardToReplicas, token); }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.SetSettingsAsync"/>.
+        /// </summary>
+        public JObject SetSettings(JObject settings, bool forwardToReplicas = false)
+        { return SetSettings(settings, null, forwardToReplicas); }
+
+        /// <summary>
+        /// List all user keys associated with this index along with their associated ACLs.
+        /// </summary>
+        [Obsolete("ListUserKeysAsync is deprecated, please use ListApiKeysAsync instead.")]
+        public Task<JObject> ListUserKeysAsync(CancellationToken token = default(CancellationToken))
+        { return ListUserKeysAsync(null, token); }
+
+        /// <summary>
+        /// List all api keys associated with this index along with their associated ACLs.
+        /// </summary>
+        public Task<JObject> ListApiKeysAsync(CancellationToken token = default(CancellationToken))
+        { return ListApiKeysAsync(null, token); }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.ListApiKeysAsync"/>.
+        /// </summary>
+        [Obsolete("ListUserKeys is deprecated, please use ListApiKeys instead.")]
+        public JObject ListUserKeys()
+        {
+            return ListUserKeys(null); 
+        }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.ListApiKeysAsync"/>.
+        /// </summary>
+        public JObject ListApiKeys()
+        {
+            return ListApiKeys(null);
+        }
+
+        /// <summary>
+        /// Get ACL of a user key associated with this index.
+        /// </summary>
+        [Obsolete("GetUserKeyACLAsync is deprecated, please use GetUserApiACLAsync instead.")]
+        public Task<JObject> GetUserKeyACLAsync(string key, CancellationToken token = default(CancellationToken))
+        { return GetUserKeyACLAsync(key, null, token); }
+
+        /// <summary>
+        /// Get ACL of an api key associated with this index.
+        /// </summary>
+        public Task<JObject> GetApiKeyACLAsync(string key, CancellationToken token = default(CancellationToken))
+        { return GetApiKeyACLAsync(key, null, token); }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.GetUserKeyACLAsync"/>.
+        /// </summary>
+        [Obsolete("GetUserKeyACL is deprecated, please use GetApiKeyACL instead.")]
+        public JObject GetUserKeyACL(string key)
+        { return GetUserKeyACL(key, null); }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.GetApiKeyACLAsync"/>.
+        /// </summary>
+        public JObject GetApiKeyACL(string key)
+        { return GetApiKeyACL(key, null); }
+
+        /// <summary>
+        /// Delete an existing user key associated with this index.
+        /// </summary>
+        [Obsolete("DeleteUserKeyAsync is deprecated, please use DeleteApiKeyAsync instead.")]
+        public Task<JObject> DeleteUserKeyAsync(string key, CancellationToken token = default(CancellationToken))
+        { return DeleteUserKeyAsync(key, null, token); }
+
+        /// <summary>
+        /// Delete an existing api key associated with this index.
+        /// </summary>
+        public Task<JObject> DeleteApiKeyAsync(string key, CancellationToken token = default(CancellationToken))
+        { return DeleteApiKeyAsync(key, null, token); }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.DeleteApiKeyAsync"/>.
+        /// </summary>
+        [Obsolete("DeleteUserKey is deprecated, please use DeleteApiKey instead.")]
+        public JObject DeleteUserKey(string key)
+        { return DeleteUserKey(key, null); }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.DeleteApiKeyAsync"/>.
+        /// </summary>
+        public JObject DeleteApiKey(string key)
+        { return DeleteApiKey(key, null); }
+
+        /// <summary>
+        /// Create a new user key associated with this index.
+        /// </summary>
+        /// <param name="parameters">the list of parameters for this key. Defined by a Dictionnary that 
+        ///     can contains the following values:
+        ///     - acl: array of string
+        ///     - validity: int
+        ///     - referers: array of string
+        ///     - description: string
+        ///     - maxHitsPerQuery: integer
+        ///     - queryParameters: string
+        ///     - maxQueriesPerIPPerHour: integer
+        ///     <returns>Returns an object with a "key" string attribute containing the new key.</returns>
+        /// <param name="token"></param>
+        [Obsolete("AddUserKeyAsync is deprecated, please use AddApiKeyAsync instead.")]
+        public Task<JObject> AddUserKeyAsync(Dictionary<string, object> parameters, CancellationToken token = default(CancellationToken))
+        { return AddUserKeyAsync(parameters, null, token); }
+
+        /// <summary>
+        /// Create a new api key associated with this index.
+        /// </summary>
+        /// <param name="parameters">the list of parameters for this key. Defined by a Dictionnary that 
+        ///     can contains the following values:
+        ///     - acl: array of string
+        ///     - validity: int
+        ///     - referers: array of string
+        ///     - description: string
+        ///     - maxHitsPerQuery: integer
+        ///     - queryParameters: string
+        ///     - maxQueriesPerIPPerHour: integer
+        ///     <returns>Returns an object with a "key" string attribute containing the new key.</returns>
+        /// <param name="token"></param>
+        public Task<JObject> AddApiKeyAsync(Dictionary<string, object> parameters, CancellationToken token = default(CancellationToken))
+        { return AddApiKeyAsync(parameters, null, token); }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.AddApiKeyAsync"/>.
+        /// </summary>
+        [Obsolete("AddUserKey is deprecated, please use AddApiKey instead.")]
+        public JObject AddUserKey(Dictionary<string, object> parameters)
+        { return AddUserKey(parameters, null); }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.AddApiKeyAsync"/>.
+        /// </summary>
+        public JObject AddApiKey(Dictionary<string, object> parameters)
+        { return AddApiKey(parameters, null); }
+
+        /// <summary>
+        /// Create a new user key associated with this index.
+        /// </summary>
+        /// <param name="acls">The list of ACL for this key. Defined by an array of strings that can contains the following values:
+        ///     - search: allow searching (https and http)
+        ///     - addObject: allow adding/updating an object in the index (https only)
+        ///     - deleteObject : allow deleting an existing object (https only)
+        ///     - deleteIndex : allow deleting an index (https only)
+        ///     - settings : allow getting index settings (https only)
+        ///     - editSettings : allow changing index settings (https only)</param>
+        /// <param name="validity">The number of seconds after which the key will be automatically removed (0 means no time limit for this key).</param>
+        /// <param name="maxQueriesPerIPPerHour">Specify the maximum number of API calls allowed from an IP address per hour.  Defaults to 0 (no rate limit).</param>
+        /// <param name="maxHitsPerQuery">Specify the maximum number of hits this API key can retrieve in one call. Defaults to 0 (unlimited).</param>
+        /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
+        [Obsolete("AddUserKeyAsync is deprecated, please use AddApiKeyAsync instead.")]
+        public Task<JObject> AddUserKeyAsync(IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0)
+        { return AddUserKeyAsync(acls, null, validity, maxQueriesPerIPPerHour, maxHitsPerQuery); }
+
+        /// <summary>
+        /// Create a new api key associated with this index.
+        /// </summary>
+        /// <param name="acls">The list of ACL for this key. Defined by an array of strings that can contains the following values:
+        ///     - search: allow searching (https and http)
+        ///     - addObject: allow adding/updating an object in the index (https only)
+        ///     - deleteObject : allow deleting an existing object (https only)
+        ///     - deleteIndex : allow deleting an index (https only)
+        ///     - settings : allow getting index settings (https only)
+        ///     - editSettings : allow changing index settings (https only)</param>
+        /// <param name="validity">The number of seconds after which the key will be automatically removed (0 means no time limit for this key).</param>
+        /// <param name="maxQueriesPerIPPerHour">Specify the maximum number of API calls allowed from an IP address per hour.  Defaults to 0 (no rate limit).</param>
+        /// <param name="maxHitsPerQuery">Specify the maximum number of hits this API key can retrieve in one call. Defaults to 0 (unlimited).</param>
+        /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
+        public Task<JObject> AddApiKeyAsync(IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0)
+        { return AddApiKeyAsync(acls, null, validity, maxQueriesPerIPPerHour, maxHitsPerQuery); }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.AddApiKeyAsync"/>.
+        /// </summary>
+        [Obsolete("AddUserKey is deprecated, please use AddApiKey instead.")]
+        public JObject AddUserKey(IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0)
+        { return AddUserKey(acls, null, validity, maxQueriesPerIPPerHour, maxHitsPerQuery); }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.AddApiKeyAsync"/>.
+        /// </summary>
+        public JObject AddApiKey(IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0)
+        { return AddApiKey(acls, null, validity, maxQueriesPerIPPerHour, maxHitsPerQuery); }
+
+        /// <summary>
+        /// Update a user key associated to this index.
+        /// </summary>
+        /// <param name="key">The user key</param>
+        /// <param name="parameters">the list of parameters for this key. Defined by a Dictionnary that 
+        ///     can contains the following values:
+        ///     - acl: array of string
+        ///     - validity: int
+        ///     - referers: array of string
+        ///     - description: string
+        ///     - maxHitsPerQuery: integer
+        ///     - queryParameters: string
+        ///     - maxQueriesPerIPPerHour: integer
+        ///     <returns>Returns an object with a "key" string attribute containing the new key.</returns>
+        /// <param name="token"></param>
+        [Obsolete("UpdateUserKeyAsync is deprecated, please use UpdateApiKeyAsync instead.")]
+        public Task<JObject> UpdateUserKeyAsync(string key, Dictionary<string, object> parameters, CancellationToken token = default(CancellationToken))
+        { return UpdateUserKeyAsync(key, parameters, null, token); }
+
+
+        /// <summary>
+        /// Update an api key associated to this index.
+        /// </summary>
+        /// <param name="key">The user key</param>
+        /// <param name="parameters">the list of parameters for this key. Defined by a Dictionnary that 
+        ///     can contains the following values:
+        ///     - acl: array of string
+        ///     - validity: int
+        ///     - referers: array of string
+        ///     - description: string
+        ///     - maxHitsPerQuery: integer
+        ///     - queryParameters: string
+        ///     - maxQueriesPerIPPerHour: integer
+        ///     <returns>Returns an object with a "key" string attribute containing the new key.</returns>
+        /// <param name="token"></param>
+        public Task<JObject> UpdateApiKeyAsync(string key, Dictionary<string, object> parameters, CancellationToken token = default(CancellationToken))
+        { return UpdateApiKeyAsync(key, parameters, null, token); }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.UpdateApiKeyAsync"/>.
+        /// </summary>
+        [Obsolete("UpdateUserKey is deprecated, please use UpdateApiKey instead.")]
+        public JObject UpdateUserKey(string key, Dictionary<string, object> parameters)
+        { return UpdateUserKey(key, parameters, null); }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.UpdateApiKeyAsync"/>.
+        /// </summary>
+        public JObject UpdateApiKey(string key, Dictionary<string, object> parameters)
+        { return UpdateApiKey(key, parameters, null); }
+
+        /// <summary>
+        /// Update a user key associated to this index.
+        /// </summary>
+        /// <param name="key">The user key</param>
+        /// <param name="acls">The list of ACL for this key. Defined by an array of strings that can contains the following values:
+        ///     - search: allow searching (https and http)
+        ///     - addObject: allow adding/updating an object in the index (https only)
+        ///     - deleteObject : allow deleting an existing object (https only)
+        ///     - deleteIndex : allow deleting an index (https only)
+        ///     - settings : allow getting index settings (https only)
+        ///     - editSettings : allow changing index settings (https only)</param>
+        /// <param name="validity">The number of seconds after which the key will be automatically removed (0 means no time limit for this key).</param>
+        /// <param name="maxQueriesPerIPPerHour">Specify the maximum number of API calls allowed from an IP address per hour.  Defaults to 0 (no rate limit).</param>
+        /// <param name="maxHitsPerQuery">Specify the maximum number of hits this API key can retrieve in one call. Defaults to 0 (unlimited).</param>
+        /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
+        [Obsolete("UpdateUserKeyAsync is deprecated, please use UpdateApiKeyAsync instead.")]
+        public Task<JObject> UpdateUserKeyAsync(string key, IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0)
+        { return UpdateUserKeyAsync(key, acls, null, validity, maxQueriesPerIPPerHour, maxHitsPerQuery); }
+
+        /// <summary>
+        /// Update an api key associated to this index.
+        /// </summary>
+        /// <param name="key">The user key</param>
+        /// <param name="acls">The list of ACL for this key. Defined by an array of strings that can contains the following values:
+        ///     - search: allow searching (https and http)
+        ///     - addObject: allow adding/updating an object in the index (https only)
+        ///     - deleteObject : allow deleting an existing object (https only)
+        ///     - deleteIndex : allow deleting an index (https only)
+        ///     - settings : allow getting index settings (https only)
+        ///     - editSettings : allow changing index settings (https only)</param>
+        /// <param name="validity">The number of seconds after which the key will be automatically removed (0 means no time limit for this key).</param>
+        /// <param name="maxQueriesPerIPPerHour">Specify the maximum number of API calls allowed from an IP address per hour.  Defaults to 0 (no rate limit).</param>
+        /// <param name="maxHitsPerQuery">Specify the maximum number of hits this API key can retrieve in one call. Defaults to 0 (unlimited).</param>
+        /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
+        public Task<JObject> UpdateApiKeyAsync(string key, IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0)
+        { return UpdateApiKeyAsync(key, acls, null, validity, maxQueriesPerIPPerHour, maxHitsPerQuery); }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.UpdateApiKeyAsync"/>.
+        /// </summary>
+        [Obsolete("UpdateUserKey is deprecated, please use UpdateApiKey instead.")]
+        public JObject UpdateUserKey(string key, IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0)
+        { return UpdateUserKey(key, acls, null, validity, maxQueriesPerIPPerHour, maxHitsPerQuery); }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.UpdateApiKeyAsync"/>.
+        /// </summary>
+        public JObject UpdateApiKey(string key, IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0)
+        { return UpdateApiKey(key, acls, null, validity, maxQueriesPerIPPerHour, maxHitsPerQuery); }
+
+        /// <summary>
+        /// Perform a search with disjunctive facets generating as many queries as number of disjunctive facets
+        /// </summary>
+        /// <param name="query">The query.</param>
+        /// <param name="disjunctiveFacets">The array of disjunctive facets.</param>
+        /// <param name="requestOptions"></param>
+        /// <param name="refinements">The current refinements. Example: { "my_facet1" => ["my_value1", "my_value2"], "my_disjunctive_facet1" => ["my_value1", "my_value2"] }.</param>
+        async public Task<JObject> SearchDisjunctiveFacetingAsync(Query query, IEnumerable<string> disjunctiveFacets, Dictionary<string, IEnumerable<string>> refinements = null)
+        { return await SearchDisjunctiveFacetingAsync(query, disjunctiveFacets, null, refinements); }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.UpdateUserKeyAsync"/>.
+        /// </summary>
+        public JObject SearchDisjunctiveFaceting(Query query, IEnumerable<string> disjunctiveFacets, Dictionary<string, IEnumerable<string>> refinements = null)
+        { return SearchDisjunctiveFaceting(query, disjunctiveFacets, null, refinements); }
+
+        /// <summary>
+        /// Search/Browse all synonyms
+        /// </summary>
+        /// <param name="query">The query string</param>
+        /// <param name="types">Specify the types</param>
+        /// <param name="page">The page to fetch</param>
+        /// <param name="hitsPerPage">number of synonyms to fetch</param>
+        /// <param name="token"></param>
+        public Task<JObject> SearchSynonymsAsync(string query, IEnumerable<SynonymType> types = null, int? page = null, int? hitsPerPage = null, CancellationToken token = default(CancellationToken))
+        { return SearchSynonymsAsync(query, null, types, page, hitsPerPage, token); }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.SearchSynonymsAsync"/>.
+        /// </summary>
+        /// <param name="query">The query string</param>
+        /// <param name="types">Specify the types</param>
+        /// <param name="page">The page to fetch</param>
+        /// <param name="hitsPerPage">number of synonyms to fetch</param>
+        public JObject SearchSynonyms(string query, IEnumerable<SynonymType> types = null, int? page = null, int? hitsPerPage = null)
+        { return SearchSynonyms(query, null, types, page, hitsPerPage); }
+
+        /// <summary>
+        /// Search/Browse all synonyms
+        /// </summary>
+        /// <param name="query">The query string</param>
+        /// <param name="types">Specify the types</param>
+        /// <param name="page">The page to fetch</param>
+        /// <param name="hitsPerPage">number of synonyms to fetch</param>
+        /// <param name="token"></param>
+        public Task<JObject> SearchSynonymsAsync(string query, IEnumerable<string> types = null, int? page = null, int? hitsPerPage = null, CancellationToken token = default(CancellationToken))
+        { return SearchSynonymsAsync(query, null, types, page, hitsPerPage, token); }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.SearchSynonymsAsync"/>.
+        /// </summary>
+        /// <param name="query">The query string</param>
+        /// <param name="types">Specify the types</param>
+        /// <param name="page">The page to fetch</param>
+        /// <param name="hitsPerPage">number of synonyms to fetch</param>
+        public JObject SearchSynonyms(string query, IEnumerable<string> types = null, int? page = null, int? hitsPerPage = null)
+        { return SearchSynonyms(query, null, types, page, hitsPerPage); }
+
+        /// <summary>
+        /// Get one synonym
+        /// </summary>
+        /// <param name="objectID">The objectID of the synonym</param>
+        /// <param name="token"></param>
+        public Task<JObject> GetSynonymAsync(string objectID, CancellationToken token = default(CancellationToken))
+        { return GetSynonymAsync(objectID, null, token); }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.GetSynonymAsync"/>.
+        /// </summary>
+        /// <param name="objectID">The objectID of the synonym</param>
+        public JObject GetSynonym(string objectID)
+        { return GetSynonym(objectID, null); }
+
+        /// <summary>
+        /// Delete one synonym
+        /// </summary>
+        /// <param name="objectID">The objectID of the synonym</param>
+        /// <param name="forwardToReplicas">Forward the operation to the replica indices</param>
+        /// <param name="token"></param>
+        public Task<JObject> DeleteSynonymAsync(string objectID, bool forwardToReplicas = false, CancellationToken token = default(CancellationToken))
+        { return DeleteSynonymAsync(objectID, null, forwardToReplicas, token); }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.DeleteSynonymAsync"/>.
+        /// </summary>
+        /// <param name="objectID">The objectID of the synonym</param>
+        /// <param name="forwardToReplicas">Forward the operation to the replica indices</param>
+        public JObject DeleteSynonym(string objectID, bool forwardToReplicas = false)
+        { return DeleteSynonym(objectID, null, forwardToReplicas); }
+
+        /// <summary>
+        /// Delete all synonym set
+        /// </summary>
+        /// <param name="forwardToReplicas">Forward the operation to the replica indices</param>
+        /// <param name="token"></param>
+        public Task<JObject> ClearSynonymsAsync(bool forwardToReplicas = false, CancellationToken token = default(CancellationToken))
+        { return ClearSynonymsAsync(null, forwardToReplicas, token); }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.BrowseFromAsync"/>.
+        /// </summary>
+        /// <param name="forwardToReplicas">Forward the operation to the replica indices</param>
+        public JObject ClearSynonyms(bool forwardToReplicas = false)
+        { return ClearSynonyms(null, forwardToReplicas); }
+
+        /// <summary>
+        /// Add or Replace a list of synonyms 
+        /// </summary>
+        /// <param name="objects"></param>
+        /// <param name="forwardToReplicas">Forward the operation to the replica indices</param>
+        /// <param name="replaceExistingSynonyms">Replace the existing synonyms with this batch</param>
+        /// <param name="token"></param>
+        public Task<JObject> BatchSynonymsAsync(IEnumerable<object> objects, bool forwardToReplicas = false, bool replaceExistingSynonyms = false, CancellationToken token = default(CancellationToken))
+        { return BatchSynonymsAsync(objects, null, forwardToReplicas, replaceExistingSynonyms, token); }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.BatchSynonymsAsync"/>.
+        /// </summary>
+        /// <param name="objects"></param>
+        /// <param name="forwardToReplicas">Forward the operation to the replica indices</param>
+        /// <param name="replaceExistingSynonyms">Replace the existing synonyms with this batch</param>
+        public JObject BatchSynonyms(IEnumerable<object> objects, bool forwardToReplicas = false, bool replaceExistingSynonyms = false)
+        { return BatchSynonyms(objects, null, forwardToReplicas, replaceExistingSynonyms); }
+
+        /// <summary>
+        /// Update one synonym
+        /// </summary>
+        /// <param name="objectID">The objectID of the synonym</param>
+        /// <param name="content">The new content of this synonym</param>
+        /// <param name="forwardToReplicas">Forward the operation to the replica indices</param>
+        /// <param name="token"></param>
+        public Task<JObject> SaveSynonymAsync(string objectID, object content, bool forwardToReplicas = false, CancellationToken token = default(CancellationToken))
+        { return SaveSynonymAsync(objectID, content, null, forwardToReplicas, token); }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.SaveSynonymAsync"/>.
+        /// </summary>
+        /// <param name="objectID"></param>
+        /// <param name="content"></param>
+        /// <param name="forwardToReplicas">Forward the operation to the replica indices</param>
+        /// <param name="replaceExistingSynonyms"></param>
+        public JObject SaveSynonym(string objectID, object content, bool forwardToReplicas = false, bool replaceExistingSynonyms = false)
+        { return SaveSynonym(objectID, content, null, forwardToReplicas, replaceExistingSynonyms); }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.SearchForFacetValuestAsync"/>.
+        /// </summary>
+        /// <param name="facetName">Name of the facet</param>
+        /// <param name="facetQuery">Current query</param>
+        /// <param name="queryParams">Optional query parameter</param>
+        public JObject SearchForFacetValues(string facetName, string facetQuery, Query queryParams = null)
+        { return SearchForFacetValues(facetName, facetQuery, null, queryParams); }
+
+        ///  <summary>
+        /// = kept for backward compatibility - Synchronously call <see cref="Index.SearchFacetAsync"/>.
+        ///  </summary>
+        /// <param name="facetName">Name of the facet</param>
+        /// <param name="facetQuery">Current query</param>
+        /// <param name="queryParams">Optional query parameter</param>
+        public JObject SearchFacet(string facetName, string facetQuery, Query queryParams = null)
+        { return SearchFacet(facetName, facetQuery, null, queryParams); }
+
+        /// <summary>
+        /// Search for facets async
+        /// </summary>
+        /// <param name="facetName">Name of the facet</param>
+        /// <param name="facetQuery">Current Query</param>
+        /// <param name="queryParams">Optional query parameter</param>
+        /// <param name="token"></param>
+        public Task<JObject> SearchFacetAsync(string facetName, string facetQuery, Query queryParams = null, CancellationToken token = default(CancellationToken))
+        { return SearchFacetAsync(facetName, facetQuery, null, queryParams, token); }
+
+        /// <summary>
+        /// Search for facets async = kept for backward compatibility
+        /// </summary>
+        /// <param name="facetName">Name of the facet</param>
+        /// <param name="facetQuery">Current Query</param>
+        /// <param name="queryParams">Optional query parameter</param>
+        /// <param name="token"></param>
+        public Task<JObject> SearchForFacetValuesAsync(string facetName, string facetQuery, Query queryParams = null, CancellationToken token = default(CancellationToken))
+        { return SearchForFacetValuesAsync(facetName, facetQuery, null, queryParams, token); }
+
+        /// <summary>
+        ///  Save a new rule in the index.
+        /// </summary>
+        /// <param name="queryRule">The body of the rule to save (must contain an objectID attribute).</param>
+        /// <param name="forwardToReplicas">whether to forward to replicas or not (defaults to false)</param>
+        /// <param name="token"></param>
+        public Task<JObject> SaveRuleAsync(JObject queryRule, bool forwardToReplicas = false, CancellationToken token = default(CancellationToken))
+        { return SaveRuleAsync(queryRule, null, forwardToReplicas, token); }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.SaveRuleAsync"/>.
+        /// </summary>
+        /// <param name="queryRule">The object to save (must contain an objectID attribute).</param>
+        /// <param name="forwardToReplicas">whether to forward to replicas or not (defaults to false)</param>
+        public JObject SaveRule(JObject queryRule, bool forwardToReplicas = false)
+        { return SaveRule(queryRule, null, forwardToReplicas); }
+
+        /// <summary>
+        ///  Retrieve a rule from the index with the specified objectID.
+        /// </summary>
+        /// <param name="objectID">The objectID of the rule to retrieve.</param>
+        /// <param name="token"></param>
+        public Task<JObject> GetRuleAsync(string objectID, CancellationToken token = default(CancellationToken))
+        { return GetRuleAsync(objectID, null, token); }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.GetRuleAsync"/>.
+        /// </summary>
+        /// <param name="objectID">The objectID of the rule to retrieve.</param>
+        public JObject GetRule(string objectID)
+        { return GetRule(objectID, null); }
+
+        /// <summary>
+        ///  Search for rules inside the index.
+        /// </summary>
+        /// <param name="query">the query rules</param>
+        /// <param name="token"></param>
+        public Task<JObject> SearchRulesAsync(RuleQuery query = null, CancellationToken token = default(CancellationToken))
+        { return SearchRulesAsync(null, query, token); }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.SearchRulesAsync"/>.
+        /// </summary>
+        /// <param name="query">the query rules</param>
+        public JObject SearchRules(RuleQuery query = null)
+        { return SearchRules(null, query); }
+
+        /// <summary>
+        ///  Delete a rule from the index with the specified objectID.
+        /// </summary>
+        /// <param name="objectID">The objectID of the rule to retrieve.</param>
+        /// <param name="forwardToReplicas">whether to forward to replicas or not (defaults to false)</param>
+        /// <param name="token"></param>
+        public Task<JObject> DeleteRuleAsync(string objectID, bool forwardToReplicas = false, CancellationToken token = default(CancellationToken))
+        { return DeleteRuleAsync(objectID, null, forwardToReplicas, token); }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.DeleteRuleAsync"/>.
+        /// </summary>
+        /// <param name="objectID">The objectID of the rule to retrieve.</param>
+        /// <param name="forwardToReplicas">whether to forward to replicas or not (defaults to false)</param>
+        public JObject DeleteRule(string objectID, bool forwardToReplicas = false)
+        { return DeleteRule(objectID, null, forwardToReplicas); }
+
+        /// <summary>
+        /// Clear all the rules of an index.
+        /// </summary>
+        /// <param name="forwardToReplicas">whether to forward to replicas or not (defaults to false)</param>
+        /// <param name="token"></param>
+        public Task<JObject> ClearRulesAsync(bool forwardToReplicas = false, CancellationToken token = default(CancellationToken))
+        { return ClearRulesAsync(null, forwardToReplicas, token); }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.ClearRulesAsync"/>.
+        /// </summary>
+        /// <param name="forwardToReplicas">whether to forward to replicas or not (defaults to false)</param>
+        public JObject ClearRules(bool forwardToReplicas = false)
+        { return ClearRules(null, forwardToReplicas); }
+
+        /// <summary>
+        ///  Save a batch of new rules in the index.
+        /// </summary>
+        /// <param name="queryRules">Batch of rules to be added to the index (must contain an objectID attribute).</param>
+        /// <param name="forwardToReplicas">whether to forward to replicas or not (defaults to false)</param>
+        /// <param name="clearExistingRules">whether to clear existing rules in the index or not (defaults to false)</param>
+        public Task<JObject> BatchRulesAsync(IEnumerable<JObject> queryRules, bool forwardToReplicas = false, bool clearExistingRules = false, CancellationToken token = default(CancellationToken))
+        { return BatchRulesAsync(queryRules, null, forwardToReplicas, clearExistingRules, token); }
+
+        /// <summary>
+        /// Synchronously call <see cref="Index.BatchRulesAsync"/>.
+        /// </summary>
+        /// <param name="queryRules">The object to save (must contain an objectID attribute).</param>
+        /// <param name="forwardToReplicas">whether to forward to replicas or not (defaults to false)</param>
+        /// <param name="clearExistingRules">whether to clear existing rules in the index or not (defaults to false)</param>
+        public JObject BatchRules(IEnumerable<JObject> queryRules, bool forwardToReplicas = false, bool clearExistingRules = false)
+        { return BatchRules(queryRules, null, forwardToReplicas, clearExistingRules); }
+
     }
 }

--- a/Algolia.Search/Index.cs
+++ b/Algolia.Search/Index.cs
@@ -34,6 +34,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System.Collections;
 using System.Threading;
+using Algolia.Search.Models;
 
 
 namespace Algolia.Search
@@ -64,15 +65,15 @@ namespace Algolia.Search
         /// <param name="content">The object you want to add to the index.</param>
         /// <param name="objectId">Optional objectID you want to attribute to this object (if the attribute already exists the old object will be overwritten).</param>
         /// <returns>An object that contains an "objectID" attribute.</returns>
-        public Task<JObject> AddObjectAsync(object content, string objectId = null, CancellationToken token = default(CancellationToken))
+        public Task<JObject> AddObjectAsync(object content, string objectId = null, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
             if (string.IsNullOrWhiteSpace(objectId))
             {
-                return _client.ExecuteRequest(AlgoliaClient.callType.Write, "POST", string.Format("/1/indexes/{0}", _urlIndexName), content, token);
+                return _client.ExecuteRequest(AlgoliaClient.callType.Write, "POST", string.Format("/1/indexes/{0}", _urlIndexName), content, token, requestOptions);
             }
             else
             {
-                return _client.ExecuteRequest(AlgoliaClient.callType.Write, "PUT", string.Format("/1/indexes/{0}/{1}", _urlIndexName, WebUtility.UrlEncode(objectId)), content, token);
+                return _client.ExecuteRequest(AlgoliaClient.callType.Write, "PUT", string.Format("/1/indexes/{0}/{1}", _urlIndexName, WebUtility.UrlEncode(objectId)), content, token, requestOptions);
             }
         }
 
@@ -82,9 +83,9 @@ namespace Algolia.Search
         /// <param name="content">The object you want to add to the index.</param>
         /// <param name="objectId">Optional objectID you want to attribute to this object (if the attribute already exists the old object will be overwritten).</param>
         /// <returns>An object that contains an "objectID" attribute.</returns>
-        public JObject AddObject(object content, string objectId = null)
+        public JObject AddObject(object content, string objectId = null, RequestOptions requestOptions = null)
         {
-            return AddObjectAsync(content, objectId).GetAwaiter().GetResult();
+            return AddObjectAsync(content, objectId, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -92,7 +93,7 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="objects">An array of objects to add. If the objects contains objectIDs, they will be used.</param>
         /// <returns>An object containing an "objectIDs" attribute (array of string).</returns>
-        public Task<JObject> AddObjectsAsync(IEnumerable<object> objects, CancellationToken token = default(CancellationToken))
+        public Task<JObject> AddObjectsAsync(IEnumerable<object> objects, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
             List<object> requests = new List<object>();
             foreach (object obj in objects) {
@@ -103,7 +104,7 @@ namespace Algolia.Search
             }
             Dictionary<string, object> batch = new Dictionary<string, object>();
             batch["requests"] = requests;
-            return _client.ExecuteRequest(AlgoliaClient.callType.Write, "POST", string.Format("/1/indexes/{0}/batch", _urlIndexName), batch, token);
+            return _client.ExecuteRequest(AlgoliaClient.callType.Write, "POST", string.Format("/1/indexes/{0}/batch", _urlIndexName), batch, token, requestOptions);
         }
 
         /// <summary>
@@ -111,9 +112,9 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="objects">An array of objects to add. If the objects contains objectIDs, they will be used.</param>
         /// <returns>An object containing an "objectIDs" attribute (array of string).</returns>
-        public JObject AddObjects(IEnumerable<object> objects)
+        public JObject AddObjects(IEnumerable<object> objects, RequestOptions requestOptions = null)
         {
-            return AddObjectsAsync(objects).GetAwaiter().GetResult();
+            return AddObjectsAsync(objects, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -122,11 +123,11 @@ namespace Algolia.Search
         /// <param name="objectID">The unique identifier of the object to retrieve.</param>
         /// <param name="attributesToRetrieve">Optional list of attributes to retrieve.</param>
         /// <returns></returns>
-        public Task<JObject> GetObjectAsync(string objectID, IEnumerable<string> attributesToRetrieve = null, CancellationToken token = default(CancellationToken))
+        public Task<JObject> GetObjectAsync(string objectID, IEnumerable<string> attributesToRetrieve = null, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
             if (attributesToRetrieve == null)
             {
-                return _client.ExecuteRequest(AlgoliaClient.callType.Read, "GET", string.Format("/1/indexes/{0}/{1}", _urlIndexName, WebUtility.UrlEncode(objectID)), null, token);
+                return _client.ExecuteRequest(AlgoliaClient.callType.Read, "GET", string.Format("/1/indexes/{0}/{1}", _urlIndexName, WebUtility.UrlEncode(objectID)), null, token, requestOptions);
             }
             else
             {
@@ -137,7 +138,7 @@ namespace Algolia.Search
                         attributes += ",";
                     attributes += WebUtility.UrlEncode(attr);
                 }
-                return _client.ExecuteRequest(AlgoliaClient.callType.Read, "GET", string.Format("/1/indexes/{0}/{1}?attributesToRetrieve={2}", _urlIndexName, WebUtility.UrlEncode(objectID), attributes), null, token);
+                return _client.ExecuteRequest(AlgoliaClient.callType.Read, "GET", string.Format("/1/indexes/{0}/{1}?attributesToRetrieve={2}", _urlIndexName, WebUtility.UrlEncode(objectID), attributes), null, token, requestOptions);
             }
         }
 
@@ -147,9 +148,9 @@ namespace Algolia.Search
         /// <param name="objectID">The unique identifier of the object to retrieve.</param>
         /// <param name="attributesToRetrieve">Optional list of attributes to retrieve.</param>
         /// <returns></returns>
-        public JObject GetObject(string objectID, IEnumerable<string> attributesToRetrieve = null)
+        public JObject GetObject(string objectID, IEnumerable<string> attributesToRetrieve = null, RequestOptions requestOptions = null)
         {
-            return GetObjectAsync(objectID, attributesToRetrieve).GetAwaiter().GetResult();
+            return GetObjectAsync(objectID, attributesToRetrieve, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -157,7 +158,7 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="objectIDs">An array of unique identifiers of the objects to retrieve.</param>
         /// <returns></returns> 
-        public Task<JObject> GetObjectsAsync(IEnumerable<String> objectIDs, CancellationToken token = default(CancellationToken))
+        public Task<JObject> GetObjectsAsync(IEnumerable<String> objectIDs, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
             JArray requests = new JArray();
             foreach (String id in objectIDs)
@@ -169,7 +170,7 @@ namespace Algolia.Search
             }
             JObject body = new JObject();
             body.Add("requests", requests);
-            return _client.ExecuteRequest(AlgoliaClient.callType.Read, "POST", "/1/indexes/*/objects", body, token);
+            return _client.ExecuteRequest(AlgoliaClient.callType.Read, "POST", "/1/indexes/*/objects", body, token, requestOptions);
         }
 
         /// <summary>
@@ -177,7 +178,7 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="objectIDs">An array of unique identifiers of the objects to retrieve.</param>
         /// <returns></returns> 
-        public Task<JObject> GetObjectsAsync(IEnumerable<String> objectIDs, IEnumerable<string> attributesToRetrieve, CancellationToken token = default(CancellationToken))
+        public Task<JObject> GetObjectsAsync(IEnumerable<String> objectIDs, IEnumerable<string> attributesToRetrieve, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
             JArray requests = new JArray();
             var attributes = "";
@@ -200,7 +201,7 @@ namespace Algolia.Search
 
             JObject body = new JObject();
             body.Add("requests", requests);
-            return _client.ExecuteRequest(AlgoliaClient.callType.Read, "POST", "/1/indexes/*/objects", body, token);
+            return _client.ExecuteRequest(AlgoliaClient.callType.Read, "POST", "/1/indexes/*/objects", body, token, requestOptions);
         }
 
         /// <summary>
@@ -208,9 +209,9 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="objectIDs">An array of unique identifiers of the objects to retrieve.</param>
         /// <returns></returns> 
-        public JObject GetObjects(IEnumerable<String> objectIDs)
+        public JObject GetObjects(IEnumerable<String> objectIDs, RequestOptions requestOptions = null)
         {
-            return GetObjectsAsync(objectIDs).GetAwaiter().GetResult();
+            return GetObjectsAsync(objectIDs, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -219,9 +220,9 @@ namespace Algolia.Search
         /// <param name="objectIDs">An array of unique identifiers of the objects to retrieve.</param>
         /// <param name="attributesToRetrieve">list of attributes to retrieve.</param>
         /// <returns></returns> 
-        public JObject GetObjects(IEnumerable<String> objectIDs, IEnumerable<string> attributesToRetrieve)
+        public JObject GetObjects(IEnumerable<String> objectIDs, IEnumerable<string> attributesToRetrieve, RequestOptions requestOptions = null)
         {
-            return GetObjectsAsync(objectIDs, attributesToRetrieve).GetAwaiter().GetResult();
+            return GetObjectsAsync(objectIDs, attributesToRetrieve, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -229,7 +230,7 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="partialObject">The object attributes to override (must contains an objectID attribute).</param>
         /// <returns>An object containing an "updatedAt" attribute.</returns>
-        public Task<JObject> PartialUpdateObjectAsync(JObject partialObject, bool createIfNotExists = true, CancellationToken token = default(CancellationToken))
+        public Task<JObject> PartialUpdateObjectAsync(JObject partialObject, bool createIfNotExists = true, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
             string queryParam = "";
             if (partialObject["objectID"] == null)
@@ -241,7 +242,7 @@ namespace Algolia.Search
                 queryParam = "?createIfNotExists=false";
             }
             string objectID = (string)partialObject["objectID"];
-            return _client.ExecuteRequest(AlgoliaClient.callType.Write, "POST", string.Format("/1/indexes/{0}/{1}/partial{2}", _urlIndexName, WebUtility.UrlEncode(objectID), queryParam), partialObject, token);
+            return _client.ExecuteRequest(AlgoliaClient.callType.Write, "POST", string.Format("/1/indexes/{0}/{1}/partial{2}", _urlIndexName, WebUtility.UrlEncode(objectID), queryParam), partialObject, token, requestOptions);
         }
 
         /// <summary>
@@ -249,9 +250,9 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="partialObject">The object attributes to override (must contains an objectID attribute).</param>
         /// <returns>An object containing an "updatedAt" attribute.</returns>
-        public JObject PartialUpdateObject(JObject partialObject, bool createIfNotExists = true)
+        public JObject PartialUpdateObject(JObject partialObject, bool createIfNotExists = true, RequestOptions requestOptions = null)
         {
-            return PartialUpdateObjectAsync(partialObject, createIfNotExists).GetAwaiter().GetResult();
+            return PartialUpdateObjectAsync(partialObject, createIfNotExists, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -259,7 +260,7 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="objects">An array of objects to update (each object must contain an objectID attribute).</param>
         /// <returns>An object containing an "objectIDs" attribute (array of string).</returns>
-        public Task<JObject> PartialUpdateObjectsAsync(IEnumerable<JObject> objects, bool createIfNotExists = true, CancellationToken token = default(CancellationToken))
+        public Task<JObject> PartialUpdateObjectsAsync(IEnumerable<JObject> objects, bool createIfNotExists = true, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
             string action = "partialUpdateObject";
             if (!createIfNotExists)
@@ -281,7 +282,7 @@ namespace Algolia.Search
             }
             Dictionary<string, object> batch = new Dictionary<string, object>();
             batch["requests"] = requests;
-            return _client.ExecuteRequest(AlgoliaClient.callType.Write, "POST", string.Format("/1/indexes/{0}/batch", _urlIndexName), batch, token);
+            return _client.ExecuteRequest(AlgoliaClient.callType.Write, "POST", string.Format("/1/indexes/{0}/batch", _urlIndexName), batch, token, requestOptions);
         }
 
         /// <summary>
@@ -289,9 +290,9 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="objects">An array of objects to update (each object must contain an objectID attribute).</param>
         /// <returns>An object containing an "objectIDs" attribute (array of string).</returns>
-        public JObject PartialUpdateObjects(IEnumerable<JObject> objects, bool createIfNotExists = true)
+        public JObject PartialUpdateObjects(IEnumerable<JObject> objects, bool createIfNotExists = true, RequestOptions requestOptions = null)
         {
-            return PartialUpdateObjectsAsync(objects, createIfNotExists).GetAwaiter().GetResult();
+            return PartialUpdateObjectsAsync(objects, createIfNotExists, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -299,14 +300,14 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="obj">The object to save (must contain an objectID attribute).</param>
         /// <returns>An object containing an "updatedAt" attribute.</returns>
-        public Task<JObject> SaveObjectAsync(JObject obj, CancellationToken token = default(CancellationToken))
+        public Task<JObject> SaveObjectAsync(JObject obj, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
             if (obj["objectID"] == null)
             {
                 throw new AlgoliaException("objectID is missing");
             }
             string objectID = (string)obj["objectID"];
-            return _client.ExecuteRequest(AlgoliaClient.callType.Write, "PUT", string.Format("/1/indexes/{0}/{1}", _urlIndexName, WebUtility.UrlEncode(objectID)), obj, token);
+            return _client.ExecuteRequest(AlgoliaClient.callType.Write, "PUT", string.Format("/1/indexes/{0}/{1}", _urlIndexName, WebUtility.UrlEncode(objectID)), obj, token, requestOptions);
         }
 
         /// <summary>
@@ -314,9 +315,9 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="obj">The object to save (must contain an objectID attribute).</param>
         /// <returns>An object containing an "updatedAt" attribute.</returns>
-        public JObject SaveObject(JObject obj)
+        public JObject SaveObject(JObject obj, RequestOptions requestOptions = null)
         {
-            return SaveObjectAsync(obj).GetAwaiter().GetResult();
+            return SaveObjectAsync(obj, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -324,7 +325,7 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="objects">An array of objects to update (each object must contain an objectID attribute).</param>
         /// <returns>An object containing an "objectIDs" attribute (array of string).</returns>
-        public Task<JObject> SaveObjectsAsync(IEnumerable<JObject> objects, CancellationToken token = default(CancellationToken))
+        public Task<JObject> SaveObjectsAsync(IEnumerable<JObject> objects, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
             List<object> requests = new List<object>();
             foreach (JObject obj in objects)
@@ -341,7 +342,7 @@ namespace Algolia.Search
             }
             Dictionary<string, object> batch = new Dictionary<string, object>();
             batch["requests"] = requests;
-            return _client.ExecuteRequest(AlgoliaClient.callType.Write, "POST", string.Format("/1/indexes/{0}/batch", _urlIndexName), batch, token);
+            return _client.ExecuteRequest(AlgoliaClient.callType.Write, "POST", string.Format("/1/indexes/{0}/batch", _urlIndexName), batch, token, requestOptions);
         }
 
         /// <summary>
@@ -349,9 +350,9 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="objects">An array of objects to update (each object must contain an objectID attribute).</param>
         /// <returns>An object containing an "objectIDs" attribute (array of string).</returns>
-        public JObject SaveObjects(IEnumerable<JObject> objects)
+        public JObject SaveObjects(IEnumerable<JObject> objects, RequestOptions requestOptions = null)
         {
-            return SaveObjectsAsync(objects).GetAwaiter().GetResult();
+            return SaveObjectsAsync(objects, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -359,11 +360,11 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="objectID">The unique identifier of the object to delete.</param>
         /// <returns>An object containing a "deletedAt" attribute.</returns>
-        public Task<JObject> DeleteObjectAsync(string objectID, CancellationToken token = default(CancellationToken))
+        public Task<JObject> DeleteObjectAsync(string objectID, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
             if (string.IsNullOrWhiteSpace(objectID))
                 throw new ArgumentOutOfRangeException("objectID", "objectID is required.");
-            return _client.ExecuteRequest(AlgoliaClient.callType.Write, "DELETE", string.Format("/1/indexes/{0}/{1}", _urlIndexName, WebUtility.UrlEncode(objectID)), null, token);
+            return _client.ExecuteRequest(AlgoliaClient.callType.Write, "DELETE", string.Format("/1/indexes/{0}/{1}", _urlIndexName, WebUtility.UrlEncode(objectID)), null, token, requestOptions);
         }
 
         /// <summary>
@@ -371,16 +372,16 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="objectID">The unique identifier of the object to delete.</param>
         /// <returns>An object containing a "deletedAt" attribute.</returns>
-        public JObject DeleteObject(string objectID)
+        public JObject DeleteObject(string objectID, RequestOptions requestOptions = null)
         {
-            return DeleteObjectAsync(objectID).GetAwaiter().GetResult();
+            return DeleteObjectAsync(objectID, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Delete several objects.
         /// </summary>
         /// <param name="objects">An array of objectIDs to delete.</param>
-        public Task<JObject> DeleteObjectsAsync(IEnumerable<String> objects, CancellationToken token = default(CancellationToken))
+        public Task<JObject> DeleteObjectsAsync(IEnumerable<String> objects, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
             List<object> requests = new List<object>();
             foreach (object id in objects)
@@ -394,23 +395,23 @@ namespace Algolia.Search
             }
             Dictionary<string, object> batch = new Dictionary<string, object>();
             batch["requests"] = requests;
-            return _client.ExecuteRequest(AlgoliaClient.callType.Write, "POST", string.Format("/1/indexes/{0}/batch", _urlIndexName), batch, token);
+            return _client.ExecuteRequest(AlgoliaClient.callType.Write, "POST", string.Format("/1/indexes/{0}/batch", _urlIndexName), batch, token, requestOptions);
         }
 
         /// <summary>
         /// Synchronously call <see cref="Index.DeleteObjectsAsync"/>.
         /// </summary>
         /// <param name="objects">An array of objectIDs to delete.</param>
-        public JObject DeleteObjects(IEnumerable<String> objects)
+        public JObject DeleteObjects(IEnumerable<String> objects, RequestOptions requestOptions = null)
         {
-            return DeleteObjectsAsync(objects).GetAwaiter().GetResult();
+            return DeleteObjectsAsync(objects, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Delete all objects matching a query.
         /// </summary>
         /// <param name="query">The query.</param>
-        async public Task DeleteByQueryAsync(Query query)
+        async public Task DeleteByQueryAsync(Query query, RequestOptions requestOptions = null)
         {
             query.SetAttributesToRetrieve(new string[]{"objectID"});
             query.SetAttributesToHighlight(new string[]{});
@@ -418,7 +419,7 @@ namespace Algolia.Search
             query.SetNbHitsPerPage(1000);
             query.EnableDistinct(false); // force distinct=false to improve performances
 
-            JObject result = await this.BrowseFromAsync(query, null).ConfigureAwait(_client.getContinueOnCapturedContext());
+            JObject result = await this.BrowseFromAsync(query, null, default(CancellationToken), requestOptions).ConfigureAwait(_client.getContinueOnCapturedContext());
             while (((JArray)result["hits"]).Count != 0)
             {
                 int i = 0;
@@ -430,7 +431,7 @@ namespace Algolia.Search
                 }
                 var task = await this.DeleteObjectsAsync(requests).ConfigureAwait(_client.getContinueOnCapturedContext());
                 await this.WaitTaskAsync(task["taskID"].ToObject<String>()).ConfigureAwait(_client.getContinueOnCapturedContext());
-                result = await this.SearchAsync(query).ConfigureAwait(_client.getContinueOnCapturedContext());
+                result = await this.SearchAsync(query, default(CancellationToken), requestOptions).ConfigureAwait(_client.getContinueOnCapturedContext());
             }
         }
 
@@ -438,27 +439,27 @@ namespace Algolia.Search
         /// Synchronously call <see cref="Index.DeleteByQueryAsync"/>.
         /// </summary>
         /// <param name="query">The query.</param>
-        public void DeleteByQuery(Query query)
+        public void DeleteByQuery(Query query, RequestOptions requestOptions = null)
         {
-            DeleteByQueryAsync(query).GetAwaiter().GetResult();
+            DeleteByQueryAsync(query, requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Search inside the index.
         /// </summary>
         /// <param name="q">The query.</param>
-        public Task<JObject> SearchAsync(Query q, CancellationToken token = default(CancellationToken))
+        public Task<JObject> SearchAsync(Query q, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
             string paramsString = q.GetQueryString();
             if (paramsString.Length > 0)
             {
                 Dictionary<string, object> body = new Dictionary<string, object>();
                 body["params"] = paramsString;
-                return _client.ExecuteRequest(AlgoliaClient.callType.Search, "POST", string.Format("/1/indexes/{0}/query", _urlIndexName), body, token);
+                return _client.ExecuteRequest(AlgoliaClient.callType.Search, "POST", string.Format("/1/indexes/{0}/query", _urlIndexName), body, token, requestOptions);
             }
             else
             {
-                return _client.ExecuteRequest(AlgoliaClient.callType.Search, "GET", string.Format("/1/indexes/{0}", _urlIndexName), null, token);
+                return _client.ExecuteRequest(AlgoliaClient.callType.Search, "GET", string.Format("/1/indexes/{0}", _urlIndexName), null, token, requestOptions);
             }
         }
 
@@ -466,20 +467,20 @@ namespace Algolia.Search
         /// Synchronously call <see cref="Index.SearchAsync"/>.
         /// </summary>
         /// <param name="q">The query.</param>
-        public JObject Search(Query q)
+        public JObject Search(Query q, RequestOptions requestOptions = null)
         {
-            return SearchAsync(q).GetAwaiter().GetResult();
+            return SearchAsync(q, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Check to see if the asynchronous server task is complete.
         /// </summary>
         /// <param name="taskID">The id of the task returned by server.</param>
-        async public Task WaitTaskAsync(string taskID, int timeToWait = 100, CancellationToken token = default(CancellationToken))
+        async public Task WaitTaskAsync(string taskID, int timeToWait = 100, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
             while (true)
             {
-                JObject obj = await _client.ExecuteRequest(AlgoliaClient.callType.Read, "GET", string.Format("/1/indexes/{0}/task/{1}", _urlIndexName, taskID), null, token).ConfigureAwait(_client.getContinueOnCapturedContext());
+                JObject obj = await _client.ExecuteRequest(AlgoliaClient.callType.Read, "GET", string.Format("/1/indexes/{0}/task/{1}", _urlIndexName, taskID), null, token, requestOptions).ConfigureAwait(_client.getContinueOnCapturedContext());
                 string status = (string)obj["status"];
                 if (status.Equals("published"))
                     return;
@@ -494,27 +495,27 @@ namespace Algolia.Search
         /// Synchronously call <see cref="Index.WaitTaskAsync"/>.
         /// </summary>
         /// <param name="taskID">The id of the task returned by server.</param>
-        public void WaitTask(String taskID, int timeToWait = 100)
+        public void WaitTask(String taskID, int timeToWait = 100, RequestOptions requestOptions = null)
         {
-            WaitTaskAsync(taskID, timeToWait).GetAwaiter().GetResult();
+            WaitTaskAsync(taskID, timeToWait, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Get the index settings.
         /// </summary>
         /// <returns>An object containing the settings.</returns>
-        public Task<JObject> GetSettingsAsync(CancellationToken token = default(CancellationToken))
+        public Task<JObject> GetSettingsAsync(CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
-            return _client.ExecuteRequest(AlgoliaClient.callType.Read, "GET", string.Format("/1/indexes/{0}/settings?getVersion=2", _urlIndexName), null, token);
+            return _client.ExecuteRequest(AlgoliaClient.callType.Read, "GET", string.Format("/1/indexes/{0}/settings?getVersion=2", _urlIndexName), null, token, requestOptions);
         }
 
         /// <summary>
         /// Synchronously call <see cref="Index.GetSettingsAsync"/>.
         /// </summary>
         /// <returns>An object containing the settings.</returns>
-        public JObject GetSettings()
+        public JObject GetSettings(RequestOptions requestOptions = null)
         {
-            return GetSettingsAsync().GetAwaiter().GetResult();
+            return GetSettingsAsync(default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -522,7 +523,7 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="page">The page number to browse.</param>
         /// <param name="hitsPerPage">The number of hits per page.</param>
-        public Task<JObject> BrowseAsync(int page = 0, int hitsPerPage = 1000, CancellationToken token = default(CancellationToken))
+        public Task<JObject> BrowseAsync(int page = 0, int hitsPerPage = 1000, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
             string param = "";
             if (page != 0)
@@ -535,7 +536,7 @@ namespace Algolia.Search
                 else
                     param += string.Format("&hitsPerPage={0}", hitsPerPage);
             }
-            return _client.ExecuteRequest(AlgoliaClient.callType.Read, "GET", string.Format("/1/indexes/{0}/browse{1}", _urlIndexName, param), null, token);
+            return _client.ExecuteRequest(AlgoliaClient.callType.Read, "GET", string.Format("/1/indexes/{0}/browse{1}", _urlIndexName, param), null, token, requestOptions);
         }
 
         /// <summary>
@@ -543,9 +544,9 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="page">The page number to browse.</param>
         /// <param name="hitsPerPage">The number of hits per page.</param>
-        public JObject Browse(int page = 0, int hitsPerPage = 1000)
+        public JObject Browse(int page = 0, int hitsPerPage = 1000, RequestOptions requestOptions = null)
         {
-            return BrowseAsync(page, hitsPerPage).GetAwaiter().GetResult();
+            return BrowseAsync(page, hitsPerPage, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -553,14 +554,14 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="q">The query parameters for the browse.</param>
         /// <param name="cursor">The cursor to start the browse can be empty.</param>
-        public Task<JObject> BrowseFromAsync(Query q, string cursor, CancellationToken token = default(CancellationToken))
+        public Task<JObject> BrowseFromAsync(Query q, string cursor, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
             string cursorParam = "";
             if (cursor != null && cursor.Length > 0)
             {
                 cursorParam = string.Format("&cursor={0}",  WebUtility.UrlEncode(cursor));
             }
-            return _client.ExecuteRequest(AlgoliaClient.callType.Read, "GET", string.Format("/1/indexes/{0}/browse?{1}{2}", _urlIndexName, q.GetQueryString(), cursorParam), null, token);
+            return _client.ExecuteRequest(AlgoliaClient.callType.Read, "GET", string.Format("/1/indexes/{0}/browse?{1}{2}", _urlIndexName, q.GetQueryString(), cursorParam), null, token, requestOptions);
         }
 
         /// <summary>
@@ -568,9 +569,9 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="q">The query parameters for the browse.</param>
         /// <param name="cursor">The cursor to start the browse can be empty.</param>
-        public JObject BrowseFrom(Query q, string cursor)
+        public JObject BrowseFrom(Query q, string cursor, RequestOptions requestOptions = null)
         {
-            return BrowseFromAsync(q, cursor).GetAwaiter().GetResult();
+            return BrowseFromAsync(q, cursor, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
 
         public class IndexIterator : IEnumerable<JObject> {
@@ -672,7 +673,7 @@ namespace Algolia.Search
         ///  Browse all index contents.
         /// </summary>
         /// <param name="q">The query parameters for the browse.</param>
-        public IndexIterator BrowseAll(Query q)
+        public IndexIterator BrowseAll(Query q, RequestOptions requestOptions = null)
         {
             return new IndexIterator(this, q, "");
         }
@@ -680,17 +681,17 @@ namespace Algolia.Search
         /// <summary>
         /// Delete the index contents without removing settings and index specific API keys.
         /// </summary>
-        public Task<JObject> ClearIndexAsync(CancellationToken token = default(CancellationToken))
+        public Task<JObject> ClearIndexAsync(CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
-            return _client.ExecuteRequest(AlgoliaClient.callType.Write, "POST", string.Format("/1/indexes/{0}/clear", _urlIndexName), null, token);
+            return _client.ExecuteRequest(AlgoliaClient.callType.Write, "POST", string.Format("/1/indexes/{0}/clear", _urlIndexName), null, token, requestOptions);
         }
 
         /// <summary>
         /// Synchronously call <see cref="Index.ClearIndexAsync"/>.
         /// </summary>
-        public JObject ClearIndex()
+        public JObject ClearIndex(RequestOptions requestOptions = null)
         {
-            return ClearIndexAsync().GetAwaiter().GetResult();
+            return ClearIndexAsync(default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -738,122 +739,122 @@ namespace Algolia.Search
         ///  - optionalWords: (array of strings) Specify a list of words that should be considered as optional when found in the query.
         /// </param>
         /// <param name="forwardToReplicas">Forward the operation to the replica indices</param>
-        public Task<JObject> SetSettingsAsync(JObject settings, bool forwardToReplicas = false, CancellationToken token = default(CancellationToken))
+        public Task<JObject> SetSettingsAsync(JObject settings, bool forwardToReplicas = false, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
             string changeSettingsPath = forwardToReplicas
                 ? string.Format("/1/indexes/{0}/settings?forwardToReplicas={1}", _urlIndexName, forwardToReplicas.ToString().ToLower())
                 : string.Format("/1/indexes/{0}/settings", _urlIndexName);
-            return _client.ExecuteRequest(AlgoliaClient.callType.Write, "PUT", changeSettingsPath, settings, token);
+            return _client.ExecuteRequest(AlgoliaClient.callType.Write, "PUT", changeSettingsPath, settings, token, requestOptions);
         }
 
         /// <summary>
         /// Synchronously call <see cref="Index.SetSettingsAsync"/>.
         /// </summary>
-        public JObject SetSettings(JObject settings, bool forwardToReplicas = false)
+        public JObject SetSettings(JObject settings, bool forwardToReplicas = false, RequestOptions requestOptions = null)
         {
-            return SetSettingsAsync(settings, forwardToReplicas).GetAwaiter().GetResult();
+            return SetSettingsAsync(settings, forwardToReplicas, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// List all user keys associated with this index along with their associated ACLs.
         /// </summary>
         [Obsolete("ListUserKeysAsync is deprecated, please use ListApiKeysAsync instead.")]
-        public Task<JObject> ListUserKeysAsync(CancellationToken token = default(CancellationToken))
+        public Task<JObject> ListUserKeysAsync(CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
-            return _client.ExecuteRequest(AlgoliaClient.callType.Read, "GET", string.Format("/1/indexes/{0}/keys", _urlIndexName), null, token);
+            return _client.ExecuteRequest(AlgoliaClient.callType.Read, "GET", string.Format("/1/indexes/{0}/keys", _urlIndexName), null, token, requestOptions);
         }
 
         /// <summary>
         /// List all api keys associated with this index along with their associated ACLs.
         /// </summary>
-        public Task<JObject> ListApiKeysAsync(CancellationToken token = default(CancellationToken))
+        public Task<JObject> ListApiKeysAsync(CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
-            return _client.ExecuteRequest(AlgoliaClient.callType.Read, "GET", string.Format("/1/indexes/{0}/keys", _urlIndexName), null, token);
+            return _client.ExecuteRequest(AlgoliaClient.callType.Read, "GET", string.Format("/1/indexes/{0}/keys", _urlIndexName), null, token, requestOptions);
         }
 
         /// <summary>
         /// Synchronously call <see cref="Index.ListApiKeysAsync"/>.
         /// </summary>
         [Obsolete("ListUserKeys is deprecated, please use ListApiKeys instead.")]
-        public JObject ListUserKeys()
+        public JObject ListUserKeys(RequestOptions requestOptions = null)
         {
-            return ListApiKeysAsync().GetAwaiter().GetResult();
+            return ListApiKeysAsync(default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Synchronously call <see cref="Index.ListApiKeysAsync"/>.
         /// </summary>
-        public JObject ListApiKeys()
+        public JObject ListApiKeys(RequestOptions requestOptions = null)
         {
-            return ListApiKeysAsync().GetAwaiter().GetResult();
+            return ListApiKeysAsync(default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Get ACL of a user key associated with this index.
         /// </summary>
         [Obsolete("GetUserKeyACLAsync is deprecated, please use GetUserApiACLAsync instead.")]
-        public Task<JObject> GetUserKeyACLAsync(string key, CancellationToken token = default(CancellationToken))
+        public Task<JObject> GetUserKeyACLAsync(string key, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
-            return _client.ExecuteRequest(AlgoliaClient.callType.Read, "GET", string.Format("/1/indexes/{0}/keys/{1}", _urlIndexName, key), null, token);
+            return _client.ExecuteRequest(AlgoliaClient.callType.Read, "GET", string.Format("/1/indexes/{0}/keys/{1}", _urlIndexName, key), null, token, requestOptions);
         }
 
         /// <summary>
         /// Get ACL of an api key associated with this index.
         /// </summary>
-        public Task<JObject> GetApiKeyACLAsync(string key, CancellationToken token = default(CancellationToken))
+        public Task<JObject> GetApiKeyACLAsync(string key, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
-            return _client.ExecuteRequest(AlgoliaClient.callType.Read, "GET", string.Format("/1/indexes/{0}/keys/{1}", _urlIndexName, key), null, token);
+            return _client.ExecuteRequest(AlgoliaClient.callType.Read, "GET", string.Format("/1/indexes/{0}/keys/{1}", _urlIndexName, key), null, token, requestOptions);
         }
 
         /// <summary>
         /// Synchronously call <see cref="Index.GetUserKeyACLAsync"/>.
         /// </summary>
         [Obsolete("GetUserKeyACL is deprecated, please use GetApiKeyACL instead.")]
-        public JObject GetUserKeyACL(string key)
+        public JObject GetUserKeyACL(string key, RequestOptions requestOptions = null)
         {
-            return GetApiKeyACLAsync(key).GetAwaiter().GetResult();
+            return GetApiKeyACLAsync(key, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Synchronously call <see cref="Index.GetApiKeyACLAsync"/>.
         /// </summary>
-        public JObject GetApiKeyACL(string key)
+        public JObject GetApiKeyACL(string key, RequestOptions requestOptions = null)
         {
-            return GetApiKeyACLAsync(key).GetAwaiter().GetResult();
+            return GetApiKeyACLAsync(key, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Delete an existing user key associated with this index.
         /// </summary>
         [Obsolete("DeleteUserKeyAsync is deprecated, please use DeleteApiKeyAsync instead.")]
-        public Task<JObject> DeleteUserKeyAsync(string key, CancellationToken token = default(CancellationToken))
+        public Task<JObject> DeleteUserKeyAsync(string key, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
-            return _client.ExecuteRequest(AlgoliaClient.callType.Write, "DELETE", string.Format("/1/indexes/{0}/keys/{1}", _urlIndexName, key), null, token);
+            return _client.ExecuteRequest(AlgoliaClient.callType.Write, "DELETE", string.Format("/1/indexes/{0}/keys/{1}", _urlIndexName, key), null, token, requestOptions);
         }
 
         /// <summary>
         /// Delete an existing api key associated with this index.
         /// </summary>
-        public Task<JObject> DeleteApiKeyAsync(string key, CancellationToken token = default(CancellationToken))
+        public Task<JObject> DeleteApiKeyAsync(string key, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
-            return _client.ExecuteRequest(AlgoliaClient.callType.Write, "DELETE", string.Format("/1/indexes/{0}/keys/{1}", _urlIndexName, key), null, token);
+            return _client.ExecuteRequest(AlgoliaClient.callType.Write, "DELETE", string.Format("/1/indexes/{0}/keys/{1}", _urlIndexName, key), null, token, requestOptions);
         }
 
         /// <summary>
         /// Synchronously call <see cref="Index.DeleteApiKeyAsync"/>.
         /// </summary>
         [Obsolete("DeleteUserKey is deprecated, please use DeleteApiKey instead.")]
-        public JObject DeleteUserKey(string key)
+        public JObject DeleteUserKey(string key, RequestOptions requestOptions = null)
         {
-            return DeleteApiKeyAsync(key).GetAwaiter().GetResult();
+            return DeleteApiKeyAsync(key, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Synchronously call <see cref="Index.DeleteApiKeyAsync"/>.
         /// </summary>
-        public JObject DeleteApiKey(string key)
+        public JObject DeleteApiKey(string key, RequestOptions requestOptions = null)
         {
-            return DeleteApiKeyAsync(key).GetAwaiter().GetResult();
+            return DeleteApiKeyAsync(key, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -870,9 +871,9 @@ namespace Algolia.Search
         ///   - maxQueriesPerIPPerHour: integer
         /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
         [Obsolete("AddUserKeyAsync is deprecated, please use AddApiKeyAsync instead.")]
-        public Task<JObject> AddUserKeyAsync(Dictionary<string, object> parameters, CancellationToken token = default(CancellationToken))
+        public Task<JObject> AddUserKeyAsync(Dictionary<string, object> parameters, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
-            return _client.ExecuteRequest(AlgoliaClient.callType.Write, "POST", string.Format("/1/indexes/{0}/keys", _urlIndexName), parameters, token);
+            return _client.ExecuteRequest(AlgoliaClient.callType.Write, "POST", string.Format("/1/indexes/{0}/keys", _urlIndexName), parameters, token, requestOptions);
         }
 
         /// <summary>
@@ -888,26 +889,26 @@ namespace Algolia.Search
         ///   - queryParameters: string
         ///   - maxQueriesPerIPPerHour: integer
         /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
-        public Task<JObject> AddApiKeyAsync(Dictionary<string, object> parameters, CancellationToken token = default(CancellationToken))
+        public Task<JObject> AddApiKeyAsync(Dictionary<string, object> parameters, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
-            return _client.ExecuteRequest(AlgoliaClient.callType.Write, "POST", string.Format("/1/indexes/{0}/keys", _urlIndexName), parameters, token);
+            return _client.ExecuteRequest(AlgoliaClient.callType.Write, "POST", string.Format("/1/indexes/{0}/keys", _urlIndexName), parameters, token, requestOptions);
         }
 
         /// <summary>
         /// Synchronously call <see cref="Index.AddApiKeyAsync"/>.
         /// </summary>
         [Obsolete("AddUserKey is deprecated, please use AddApiKey instead.")]
-        public JObject AddUserKey(Dictionary<string, object> parameters)
+        public JObject AddUserKey(Dictionary<string, object> parameters, RequestOptions requestOptions = null)
         {
-            return AddApiKeyAsync(parameters).GetAwaiter().GetResult();
+            return AddApiKeyAsync(parameters, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Synchronously call <see cref="Index.AddApiKeyAsync"/>.
         /// </summary>
-        public JObject AddApiKey(Dictionary<string, object> parameters)
+        public JObject AddApiKey(Dictionary<string, object> parameters, RequestOptions requestOptions = null)
         {
-            return AddApiKeyAsync(parameters).GetAwaiter().GetResult();
+            return AddApiKeyAsync(parameters, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -925,14 +926,14 @@ namespace Algolia.Search
         /// <param name="maxHitsPerQuery">Specify the maximum number of hits this API key can retrieve in one call. Defaults to 0 (unlimited).</param>
         /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
         [Obsolete("AddUserKeyAsync is deprecated, please use AddApiKeyAsync instead.")]
-        public Task<JObject> AddUserKeyAsync(IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0)
+        public Task<JObject> AddUserKeyAsync(IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, RequestOptions requestOptions = null)
         {
             Dictionary<string, object> content = new Dictionary<string, object>();
             content["acl"] = acls;
             content["validity"] = validity;
             content["maxQueriesPerIPPerHour"] = maxQueriesPerIPPerHour;
             content["maxHitsPerQuery"] = maxHitsPerQuery;
-            return AddApiKeyAsync(content);
+            return AddApiKeyAsync(content, default(CancellationToken), requestOptions);
         }
 
         /// <summary>
@@ -949,31 +950,31 @@ namespace Algolia.Search
         /// <param name="maxQueriesPerIPPerHour">Specify the maximum number of API calls allowed from an IP address per hour.  Defaults to 0 (no rate limit).</param>
         /// <param name="maxHitsPerQuery">Specify the maximum number of hits this API key can retrieve in one call. Defaults to 0 (unlimited).</param>
         /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
-        public Task<JObject> AddApiKeyAsync(IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0)
+        public Task<JObject> AddApiKeyAsync(IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, RequestOptions requestOptions = null)
         {
             Dictionary<string, object> content = new Dictionary<string, object>();
             content["acl"] = acls;
             content["validity"] = validity;
             content["maxQueriesPerIPPerHour"] = maxQueriesPerIPPerHour;
             content["maxHitsPerQuery"] = maxHitsPerQuery;
-            return AddApiKeyAsync(content);
+            return AddApiKeyAsync(content, default(CancellationToken), requestOptions);
         }
 
         /// <summary>
         /// Synchronously call <see cref="Index.AddApiKeyAsync"/>.
         /// </summary>
         [Obsolete("AddUserKey is deprecated, please use AddApiKey instead.")]
-        public JObject AddUserKey(IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0)
+        public JObject AddUserKey(IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, RequestOptions requestOptions = null)
         {
-            return AddApiKeyAsync(acls, validity, maxQueriesPerIPPerHour, maxHitsPerQuery).GetAwaiter().GetResult();
+            return AddApiKeyAsync(acls, validity, maxQueriesPerIPPerHour, maxHitsPerQuery, requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Synchronously call <see cref="Index.AddApiKeyAsync"/>.
         /// </summary>
-        public JObject AddApiKey(IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0)
+        public JObject AddApiKey(IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, RequestOptions requestOptions = null)
         {
-            return AddApiKeyAsync(acls, validity, maxQueriesPerIPPerHour, maxHitsPerQuery).GetAwaiter().GetResult();
+            return AddApiKeyAsync(acls, validity, maxQueriesPerIPPerHour, maxHitsPerQuery, requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -991,9 +992,9 @@ namespace Algolia.Search
         ///   - maxQueriesPerIPPerHour: integer
         /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
         [Obsolete("UpdateUserKeyAsync is deprecated, please use UpdateApiKeyAsync instead.")]
-        public Task<JObject> UpdateUserKeyAsync(string key, Dictionary<string, object> parameters, CancellationToken token = default(CancellationToken))
+        public Task<JObject> UpdateUserKeyAsync(string key, Dictionary<string, object> parameters, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
-            return _client.ExecuteRequest(AlgoliaClient.callType.Write, "PUT", string.Format("/1/indexes/{0}/keys/{1}", _urlIndexName, key), parameters, token);
+            return _client.ExecuteRequest(AlgoliaClient.callType.Write, "PUT", string.Format("/1/indexes/{0}/keys/{1}", _urlIndexName, key), parameters, token, requestOptions);
         }
 
 
@@ -1011,26 +1012,26 @@ namespace Algolia.Search
         ///   - queryParameters: string
         ///   - maxQueriesPerIPPerHour: integer
         /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
-        public Task<JObject> UpdateApiKeyAsync(string key, Dictionary<string, object> parameters, CancellationToken token = default(CancellationToken))
+        public Task<JObject> UpdateApiKeyAsync(string key, Dictionary<string, object> parameters, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
-            return _client.ExecuteRequest(AlgoliaClient.callType.Write, "PUT", string.Format("/1/indexes/{0}/keys/{1}", _urlIndexName, key), parameters, token);
+            return _client.ExecuteRequest(AlgoliaClient.callType.Write, "PUT", string.Format("/1/indexes/{0}/keys/{1}", _urlIndexName, key), parameters, token, requestOptions);
         }
 
         /// <summary>
         /// Synchronously call <see cref="Index.UpdateApiKeyAsync"/>.
         /// </summary>
         [Obsolete("UpdateUserKey is deprecated, please use UpdateApiKey instead.")]
-        public JObject UpdateUserKey(string key, Dictionary<string, object> parameters)
+        public JObject UpdateUserKey(string key, Dictionary<string, object> parameters, RequestOptions requestOptions = null)
         {
-            return UpdateApiKeyAsync(key, parameters).GetAwaiter().GetResult();
+            return UpdateApiKeyAsync(key, parameters, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Synchronously call <see cref="Index.UpdateApiKeyAsync"/>.
         /// </summary>
-        public JObject UpdateApiKey(string key, Dictionary<string, object> parameters)
+        public JObject UpdateApiKey(string key, Dictionary<string, object> parameters, RequestOptions requestOptions = null)
         {
-            return UpdateApiKeyAsync(key, parameters).GetAwaiter().GetResult();
+            return UpdateApiKeyAsync(key, parameters, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -1049,14 +1050,14 @@ namespace Algolia.Search
         /// <param name="maxHitsPerQuery">Specify the maximum number of hits this API key can retrieve in one call. Defaults to 0 (unlimited).</param>
         /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
         [Obsolete("UpdateUserKeyAsync is deprecated, please use UpdateApiKeyAsync instead.")]
-        public Task<JObject> UpdateUserKeyAsync(string key, IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0)
+        public Task<JObject> UpdateUserKeyAsync(string key, IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, RequestOptions requestOptions = null)
         {
             Dictionary<string, object> content = new Dictionary<string, object>();
             content["acl"] = acls;
             content["validity"] = validity;
             content["maxQueriesPerIPPerHour"] = maxQueriesPerIPPerHour;
             content["maxHitsPerQuery"] = maxHitsPerQuery;
-            return UpdateApiKeyAsync(key, content);
+            return UpdateApiKeyAsync(key, content, default(CancellationToken), requestOptions);
         }
 
         /// <summary>
@@ -1074,31 +1075,31 @@ namespace Algolia.Search
         /// <param name="maxQueriesPerIPPerHour">Specify the maximum number of API calls allowed from an IP address per hour.  Defaults to 0 (no rate limit).</param>
         /// <param name="maxHitsPerQuery">Specify the maximum number of hits this API key can retrieve in one call. Defaults to 0 (unlimited).</param>
         /// <returns>Returns an object with a "key" string attribute containing the new key.</returns>
-        public Task<JObject> UpdateApiKeyAsync(string key, IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0)
+        public Task<JObject> UpdateApiKeyAsync(string key, IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, RequestOptions requestOptions = null)
         {
             Dictionary<string, object> content = new Dictionary<string, object>();
             content["acl"] = acls;
             content["validity"] = validity;
             content["maxQueriesPerIPPerHour"] = maxQueriesPerIPPerHour;
             content["maxHitsPerQuery"] = maxHitsPerQuery;
-            return UpdateApiKeyAsync(key, content);
+            return UpdateApiKeyAsync(key, content, default(CancellationToken), requestOptions);
         }
 
         /// <summary>
         /// Synchronously call <see cref="Index.UpdateApiKeyAsync"/>.
         /// </summary>
         [Obsolete("UpdateUserKey is deprecated, please use UpdateApiKey instead.")]
-        public JObject UpdateUserKey(string key, IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0)
+        public JObject UpdateUserKey(string key, IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, RequestOptions requestOptions = null)
         {
-            return UpdateApiKeyAsync(key, acls, validity, maxQueriesPerIPPerHour, maxHitsPerQuery).GetAwaiter().GetResult();
+            return UpdateApiKeyAsync(key, acls, validity, maxQueriesPerIPPerHour, maxHitsPerQuery, requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Synchronously call <see cref="Index.UpdateApiKeyAsync"/>.
         /// </summary>
-        public JObject UpdateApiKey(string key, IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0)
+        public JObject UpdateApiKey(string key, IEnumerable<string> acls, int validity = 0, int maxQueriesPerIPPerHour = 0, int maxHitsPerQuery = 0, RequestOptions requestOptions = null)
         {
-            return UpdateApiKeyAsync(key, acls, validity, maxQueriesPerIPPerHour, maxHitsPerQuery).GetAwaiter().GetResult();
+            return UpdateApiKeyAsync(key, acls, validity, maxQueriesPerIPPerHour, maxHitsPerQuery, requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -1107,7 +1108,7 @@ namespace Algolia.Search
         /// <param name="query">The query.</param>
         /// <param name="disjunctiveFacets">The array of disjunctive facets.</param>
         /// <param name="refinements">The current refinements. Example: { "my_facet1" => ["my_value1", "my_value2"], "my_disjunctive_facet1" => ["my_value1", "my_value2"] }.</param>
-        async public Task<JObject> SearchDisjunctiveFacetingAsync(Query query, IEnumerable<string> disjunctiveFacets, Dictionary<string, IEnumerable<string>> refinements = null)
+        async public Task<JObject> SearchDisjunctiveFacetingAsync(Query query, IEnumerable<string> disjunctiveFacets, Dictionary<string, IEnumerable<string>> refinements = null, RequestOptions requestOptions = null)
         {
             if (refinements == null)
                 refinements = new Dictionary<string, IEnumerable<string>>();
@@ -1185,7 +1186,7 @@ namespace Algolia.Search
                 queries.Add(new IndexQuery(_indexName, query.clone().SetPage(0).SetNbHitsPerPage(0).EnableAnalytics(false).SetAttributesToRetrieve(new List<string>()).SetAttributesToHighlight(new List<string>()).SetAttributesToSnippet(new List<string>()).SetFacets(new String[]{disjunctiveFacet}).SetFacetFilters(filters)));
             }
         
-            JObject answers = await _client.MultipleQueriesAsync(queries).ConfigureAwait(_client.getContinueOnCapturedContext());
+            JObject answers = await _client.MultipleQueriesAsync(queries, "none", default(CancellationToken), requestOptions).ConfigureAwait(_client.getContinueOnCapturedContext());
 
             // aggregate answers
             // first answer stores the hits + regular facets
@@ -1224,9 +1225,9 @@ namespace Algolia.Search
         /// <summary>
         /// Synchronously call <see cref="Index.UpdateUserKeyAsync"/>.
         /// </summary>
-        public JObject SearchDisjunctiveFaceting(Query query, IEnumerable<string> disjunctiveFacets, Dictionary<string, IEnumerable<string>> refinements = null)
+        public JObject SearchDisjunctiveFaceting(Query query, IEnumerable<string> disjunctiveFacets, Dictionary<string, IEnumerable<string>> refinements = null, RequestOptions requestOptions = null)
         {
-            return SearchDisjunctiveFacetingAsync(query, disjunctiveFacets, refinements).GetAwaiter().GetResult();
+            return SearchDisjunctiveFacetingAsync(query, disjunctiveFacets, refinements, requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -1264,7 +1265,7 @@ namespace Algolia.Search
         /// <param name="types">Specify the types</param>
         /// <param name="page">The page to fetch</param>
         /// <param name="hitsPerPage">number of synonyms to fetch</param>
-        public Task<JObject> SearchSynonymsAsync(string query, IEnumerable<SynonymType> types = null, int? page = null, int? hitsPerPage = null, CancellationToken token = default(CancellationToken))
+        public Task<JObject> SearchSynonymsAsync(string query, IEnumerable<SynonymType> types = null, int? page = null, int? hitsPerPage = null, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
             string[] typesStr = null;
             if (types != null)
@@ -1275,7 +1276,7 @@ namespace Algolia.Search
                     typesStr[i] = SynonymsTypeToString(types.ElementAt(i));
                 }
             }
-            return SearchSynonymsAsync(query, typesStr, page, hitsPerPage, token);
+            return SearchSynonymsAsync(query, typesStr, page, hitsPerPage, token, requestOptions);
         }
         /// <summary>
         /// Synchronously call <see cref="Index.SearchSynonymsAsync"/>.
@@ -1284,10 +1285,9 @@ namespace Algolia.Search
         /// <param name="types">Specify the types</param>
         /// <param name="page">The page to fetch</param>
         /// <param name="hitsPerPage">number of synonyms to fetch</param>
-        public JObject SearchSynonyms(string query, IEnumerable<SynonymType> types = null, int? page = null, int? hitsPerPage = null)
+        public JObject SearchSynonyms(string query, IEnumerable<SynonymType> types = null, int? page = null, int? hitsPerPage = null, RequestOptions requestOptions = null)
         {
-
-            return SearchSynonymsAsync(query, types, page, hitsPerPage).GetAwaiter().GetResult();
+            return SearchSynonymsAsync(query, types, page, hitsPerPage, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
         /// <summary>
         /// Search/Browse all synonyms
@@ -1296,7 +1296,7 @@ namespace Algolia.Search
         /// <param name="types">Specify the types</param>
         /// <param name="page">The page to fetch</param>
         /// <param name="hitsPerPage">number of synonyms to fetch</param>
-        public Task<JObject> SearchSynonymsAsync(string query, IEnumerable<string> types = null, int? page = null, int? hitsPerPage = null, CancellationToken token = default(CancellationToken))
+        public Task<JObject> SearchSynonymsAsync(string query, IEnumerable<string> types = null, int? page = null, int? hitsPerPage = null, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
             Dictionary<string, object> body = new Dictionary<string, object>();
             body["query"] = query;
@@ -1310,7 +1310,7 @@ namespace Algolia.Search
                 body["page"] = page.Value;
             if (hitsPerPage.HasValue)
                 body["hitsPerPage"] = hitsPerPage.Value;
-            return _client.ExecuteRequest(AlgoliaClient.callType.Read, "POST", string.Format("/1/indexes/{0}/synonyms/search", _urlIndexName), body, token);
+            return _client.ExecuteRequest(AlgoliaClient.callType.Read, "POST", string.Format("/1/indexes/{0}/synonyms/search", _urlIndexName), body, token, requestOptions);
         }
 
         /// <summary>
@@ -1320,28 +1320,27 @@ namespace Algolia.Search
         /// <param name="types">Specify the types</param>
         /// <param name="page">The page to fetch</param>
         /// <param name="hitsPerPage">number of synonyms to fetch</param>
-        public JObject SearchSynonyms(string query, IEnumerable<string> types = null, int? page = null, int? hitsPerPage = null)
+        public JObject SearchSynonyms(string query, IEnumerable<string> types = null, int? page = null, int? hitsPerPage = null, RequestOptions requestOptions = null)
         {
-
-            return SearchSynonymsAsync(query, types, page, hitsPerPage).GetAwaiter().GetResult();
+            return SearchSynonymsAsync(query, types, page, hitsPerPage, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Get one synonym
         /// </summary>
         /// <param name="objectID">The objectID of the synonym</param>
-        public Task<JObject> GetSynonymAsync(string objectID, CancellationToken token = default(CancellationToken))
+        public Task<JObject> GetSynonymAsync(string objectID, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
-            return _client.ExecuteRequest(AlgoliaClient.callType.Read, "GET", string.Format("/1/indexes/{0}/synonyms/{1}", _urlIndexName, WebUtility.UrlEncode(objectID)), null, token);
+            return _client.ExecuteRequest(AlgoliaClient.callType.Read, "GET", string.Format("/1/indexes/{0}/synonyms/{1}", _urlIndexName, WebUtility.UrlEncode(objectID)), null, token, requestOptions);
         }
 
         /// <summary>
         /// Synchronously call <see cref="Index.GetSynonymAsync"/>.
         /// </summary>
         /// <param name="objectID">The objectID of the synonym</param>
-        public JObject GetSynonym(string objectID)
+        public JObject GetSynonym(string objectID, RequestOptions requestOptions = null)
         {
-            return GetSynonymAsync(objectID).GetAwaiter().GetResult();
+            return GetSynonymAsync(objectID, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -1349,9 +1348,9 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="objectID">The objectID of the synonym</param>
         /// <param name="forwardToReplicas">Forward the operation to the replica indices</param>
-        public Task<JObject> DeleteSynonymAsync(string objectID, bool forwardToReplicas = false, CancellationToken token = default(CancellationToken))
+        public Task<JObject> DeleteSynonymAsync(string objectID, bool forwardToReplicas = false, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
-            return _client.ExecuteRequest(AlgoliaClient.callType.Write, "DELETE", string.Format("/1/indexes/{0}/synonyms/{1}?forwardToReplicas={2}", _urlIndexName, WebUtility.UrlEncode(objectID), forwardToReplicas ? "true" : "false"), null, token);
+            return _client.ExecuteRequest(AlgoliaClient.callType.Write, "DELETE", string.Format("/1/indexes/{0}/synonyms/{1}?forwardToReplicas={2}", _urlIndexName, WebUtility.UrlEncode(objectID), forwardToReplicas ? "true" : "false"), null, token, requestOptions);
         }
 
         /// <summary>
@@ -1359,27 +1358,27 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="objectID">The objectID of the synonym</param>
         /// <param name="forwardToReplicas">Forward the operation to the replica indices</param>
-        public JObject DeleteSynonym(string objectID, bool forwardToReplicas = false)
+        public JObject DeleteSynonym(string objectID, bool forwardToReplicas = false, RequestOptions requestOptions = null)
         {
-            return DeleteSynonymAsync(objectID, forwardToReplicas).GetAwaiter().GetResult();
+            return DeleteSynonymAsync(objectID, forwardToReplicas, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
         /// Delete all synonym set
         /// </summary>
         /// <param name="forwardToReplicas">Forward the operation to the replica indices</param>
-        public Task<JObject> ClearSynonymsAsync(bool forwardToReplicas = false, CancellationToken token = default(CancellationToken))
+        public Task<JObject> ClearSynonymsAsync(bool forwardToReplicas = false, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
-            return _client.ExecuteRequest(AlgoliaClient.callType.Write, "POST", string.Format("/1/indexes/{0}/synonyms/clear?forwardToReplicas={1}", _urlIndexName, forwardToReplicas ? "true" : "false"), null, token);
+            return _client.ExecuteRequest(AlgoliaClient.callType.Write, "POST", string.Format("/1/indexes/{0}/synonyms/clear?forwardToReplicas={1}", _urlIndexName, forwardToReplicas ? "true" : "false"), null, token, requestOptions);
         }
 
         /// <summary>
         /// Synchronously call <see cref="Index.BrowseFromAsync"/>.
         /// </summary>
         /// <param name="forwardToReplicas">Forward the operation to the replica indices</param>
-        public JObject ClearSynonyms(bool forwardToReplicas = false)
+        public JObject ClearSynonyms(bool forwardToReplicas = false, RequestOptions requestOptions = null)
         {
-            return ClearSynonymsAsync(forwardToReplicas).GetAwaiter().GetResult();
+            return ClearSynonymsAsync(forwardToReplicas, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -1387,9 +1386,9 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="forwardToReplicas">Forward the operation to the replica indices</param>
         /// <param name="replaceExistingSynonyms">Replace the existing synonyms with this batch</param>
-        public Task<JObject> BatchSynonymsAsync(IEnumerable<object> objects, bool forwardToReplicas = false, bool replaceExistingSynonyms = false, CancellationToken token = default(CancellationToken))
+        public Task<JObject> BatchSynonymsAsync(IEnumerable<object> objects, bool forwardToReplicas = false, bool replaceExistingSynonyms = false, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
-            return _client.ExecuteRequest(AlgoliaClient.callType.Write, "POST", string.Format("/1/indexes/{0}/synonyms/batch?replaceExistingSynonyms={1}&forwardToReplicas={2}", _urlIndexName, replaceExistingSynonyms ? "true" : "false", forwardToReplicas ? "true" : "false"), objects, token);
+            return _client.ExecuteRequest(AlgoliaClient.callType.Write, "POST", string.Format("/1/indexes/{0}/synonyms/batch?replaceExistingSynonyms={1}&forwardToReplicas={2}", _urlIndexName, replaceExistingSynonyms ? "true" : "false", forwardToReplicas ? "true" : "false"), objects, token, requestOptions);
         }
 
         /// <summary>
@@ -1397,9 +1396,9 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="forwardToReplicas">Forward the operation to the replica indices</param>
         /// <param name="replaceExistingSynonyms">Replace the existing synonyms with this batch</param>
-        public JObject BatchSynonyms(IEnumerable<object> objects, bool forwardToReplicas = false, bool replaceExistingSynonyms = false)
+        public JObject BatchSynonyms(IEnumerable<object> objects, bool forwardToReplicas = false, bool replaceExistingSynonyms = false, RequestOptions requestOptions = null)
         {
-            return BatchSynonymsAsync(objects, forwardToReplicas, replaceExistingSynonyms).GetAwaiter().GetResult();
+            return BatchSynonymsAsync(objects, forwardToReplicas, replaceExistingSynonyms, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -1408,18 +1407,18 @@ namespace Algolia.Search
         /// <param name="objectID">The objectID of the synonym</param>
         /// <param name="content">The new content of this synonym</param>
         /// <param name="forwardToReplicas">Forward the operation to the replica indices</param>
-        public Task<JObject> SaveSynonymAsync(string objectID, object content, bool forwardToReplicas = false, CancellationToken token = default(CancellationToken))
+        public Task<JObject> SaveSynonymAsync(string objectID, object content, bool forwardToReplicas = false, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
-            return _client.ExecuteRequest(AlgoliaClient.callType.Write, "PUT", string.Format("/1/indexes/{0}/synonyms/{1}?forwardToReplicas={2}", _urlIndexName,  WebUtility.UrlEncode(objectID), forwardToReplicas ? "true" : "false"), content, token);
+            return _client.ExecuteRequest(AlgoliaClient.callType.Write, "PUT", string.Format("/1/indexes/{0}/synonyms/{1}?forwardToReplicas={2}", _urlIndexName,  WebUtility.UrlEncode(objectID), forwardToReplicas ? "true" : "false"), content, token, requestOptions);
         }
 
         /// <summary>
         /// Synchronously call <see cref="Index.SaveSynonymAsync"/>.
         /// </summary>
         /// <param name="forwardToReplicas">Forward the operation to the replica indices</param>
-        public JObject SaveSynonym(string objectID, object content, bool forwardToReplicas = false, bool replaceExistingSynonyms = false)
+        public JObject SaveSynonym(string objectID, object content, bool forwardToReplicas = false, bool replaceExistingSynonyms = false, RequestOptions requestOptions = null)
         {
-            return SaveSynonymAsync(objectID, content, forwardToReplicas).GetAwaiter().GetResult();
+            return SaveSynonymAsync(objectID, content, forwardToReplicas, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -1428,9 +1427,9 @@ namespace Algolia.Search
         /// <param name="facetName">Name of the facet</param>
         /// <param name="facetQuery">Current query</param>
         /// <param name="queryParams">Optional query parameter</param>
-        public JObject SearchForFacetValues(string facetName, string facetQuery, Query queryParams = null)
+        public JObject SearchForFacetValues(string facetName, string facetQuery, Query queryParams = null, RequestOptions requestOptions = null)
         {
-            return SearchForFacetValuesAsync(facetName, facetQuery, queryParams).GetAwaiter().GetResult();
+            return SearchForFacetValuesAsync(facetName, facetQuery, queryParams, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -1439,9 +1438,9 @@ namespace Algolia.Search
         /// <param name="facetName">Name of the facet</param>
         /// <param name="facetQuery">Current query</param>
         /// <param name="queryParams">Optional query parameter</param>
-        public JObject SearchFacet(string facetName, string facetQuery, Query queryParams = null)
+        public JObject SearchFacet(string facetName, string facetQuery, Query queryParams = null, RequestOptions requestOptions = null)
         {
-            return SearchFacetAsync(facetName, facetQuery, queryParams).GetAwaiter().GetResult();
+            return SearchFacetAsync(facetName, facetQuery, queryParams, default(CancellationToken), requestOptions).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -1450,7 +1449,7 @@ namespace Algolia.Search
         /// <param name="facetName">Name of the facet</param>
         /// <param name="facetQuery">Current Query</param>
         /// <param name="queryParams">Optional query parameter</param>
-        public Task<JObject> SearchFacetAsync(string facetName, string facetQuery, Query queryParams = null, CancellationToken token = default(CancellationToken))
+        public Task<JObject> SearchFacetAsync(string facetName, string facetQuery, Query queryParams = null, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
             if(queryParams == null)
             {
@@ -1460,7 +1459,7 @@ namespace Algolia.Search
             string paramsString = queryParams.GetQueryString();
             Dictionary<string, object> body = new Dictionary<string, object>();
             body["params"] = paramsString;
-            return _client.ExecuteRequest(AlgoliaClient.callType.Read, "POST", string.Format("/1/indexes/{0}/facets/{1}/query", _urlIndexName, facetName), body, token);
+            return _client.ExecuteRequest(AlgoliaClient.callType.Read, "POST", string.Format("/1/indexes/{0}/facets/{1}/query", _urlIndexName, facetName), body, token, requestOptions);
         }
 
         /// <summary>
@@ -1469,7 +1468,7 @@ namespace Algolia.Search
         /// <param name="facetName">Name of the facet</param>
         /// <param name="facetQuery">Current Query</param>
         /// <param name="queryParams">Optional query parameter</param>
-        public Task<JObject> SearchForFacetValuesAsync(string facetName, string facetQuery, Query queryParams = null, CancellationToken token = default(CancellationToken))
+        public Task<JObject> SearchForFacetValuesAsync(string facetName, string facetQuery, Query queryParams = null, CancellationToken token = default(CancellationToken), RequestOptions requestOptions = null)
         {
             if (queryParams == null)
             {
@@ -1479,7 +1478,7 @@ namespace Algolia.Search
             string paramsString = queryParams.GetQueryString();
             Dictionary<string, object> body = new Dictionary<string, object>();
             body["params"] = paramsString;
-            return _client.ExecuteRequest(AlgoliaClient.callType.Read, "POST", string.Format("/1/indexes/{0}/facets/{1}/query", _urlIndexName, facetName), body, token);
+            return _client.ExecuteRequest(AlgoliaClient.callType.Read, "POST", string.Format("/1/indexes/{0}/facets/{1}/query", _urlIndexName, facetName), body, token, requestOptions);
         }
     }
 }

--- a/Algolia.Search/IndexHelper.cs
+++ b/Algolia.Search/IndexHelper.cs
@@ -68,7 +68,7 @@ namespace Algolia.Search
                 if (toIndex.Count >= maxObjectsPerCall)
                 {
                     // Add or update indices
-                    taskList.Add(tempIndex.SaveObjectsAsync(toIndex));
+                    taskList.Add(tempIndex.SaveObjectsAsync(toIndex, null));
 
                     // Reset array
                     toIndex.Clear();
@@ -77,13 +77,13 @@ namespace Algolia.Search
 
             // Add or update indices for last batch
             if (toIndex.Count > 0)
-                taskList.Add(tempIndex.SaveObjectsAsync(toIndex));
+                taskList.Add(tempIndex.SaveObjectsAsync(toIndex, null));
 
             // Wait for all tasks to be done
             Task.WaitAll(taskList.ToArray());
 
             // Overwrite main index with temp index
-            return await base._client.MoveIndexAsync(tempIndexName, _indexName);
+            return await base._client.MoveIndexAsync(tempIndexName, _indexName, null);
         }
 
         /// <summary>
@@ -131,7 +131,7 @@ namespace Algolia.Search
                 if (toIndex.Count >= maxObjectsPerCall)
                 {
                     // Add or update indices
-                    taskList.Add(base.SaveObjectsAsync(toIndex));
+                    taskList.Add(base.SaveObjectsAsync(toIndex, null));
 
                     // Reset array
                     toIndex.Clear();
@@ -140,7 +140,7 @@ namespace Algolia.Search
 
             // Add or update indices for last batch
             if (toIndex.Count > 0)
-                taskList.Add(base.SaveObjectsAsync(toIndex));
+                taskList.Add(base.SaveObjectsAsync(toIndex, null));
 
             // Wait for all tasks to be done
             return await Task.WhenAll(taskList);
@@ -174,7 +174,7 @@ namespace Algolia.Search
             jObject.Add("objectID", id);
 
             // Add new index (if no matching jObject.objectID) or update
-            return base.SaveObjectAsync(jObject);
+            return base.SaveObjectAsync(jObject, null);
         }
 
         /// <summary>
@@ -217,7 +217,7 @@ namespace Algolia.Search
                 if (toIndex.Count >= maxObjectsPerCall)
                 {
                     // Delete indices
-                    taskList.Add(base.DeleteObjectsAsync(toIndex));
+                    taskList.Add(base.DeleteObjectsAsync(toIndex, null));
 
                     // Reset array
                     toIndex.Clear();
@@ -226,7 +226,7 @@ namespace Algolia.Search
 
             // Delete indices for last batch
             if (toIndex.Count > 0)
-                taskList.Add(base.DeleteObjectsAsync(toIndex));
+                taskList.Add(base.DeleteObjectsAsync(toIndex, null));
 
             // Wait for all tasks to be done
             return await Task.WhenAll(taskList);
@@ -257,7 +257,7 @@ namespace Algolia.Search
             var id = jObject.GetValue(_objectIdField).ToString();
 
             // Remove the index from Algolia
-            return base.DeleteObjectAsync(id);
+            return base.DeleteObjectAsync(id, null);
         }
 
         /// <summary>

--- a/Algolia.Search/Models/RequestOptions.cs
+++ b/Algolia.Search/Models/RequestOptions.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Algolia.Search.Models
+{
+    public class RequestOptions
+    {
+        private readonly Dictionary<string, string> _headers = new Dictionary<string, string>();
+        private readonly Dictionary<string, string> _queryParams = new Dictionary<string, string>();
+        private string _forwardedFor;
+
+        public RequestOptions SetForwardedFor(string forwardedFor)
+        {
+            _forwardedFor = forwardedFor;
+            return this;
+        }
+
+        public RequestOptions AddExtraHeader(string key, string value)
+        {
+            _headers[key] = value;
+            return this;
+        }
+
+        public RequestOptions AddExtraQueryParameters(string key, string value)
+        {
+            _queryParams[key] = value;
+            return this;
+        }
+
+        public Dictionary<String, String> GenerateExtraHeaders()
+        {
+            if (_forwardedFor != null)
+            {
+                _headers["X-Forwarded-For"] = _forwardedFor;
+            }
+            return _headers;
+        }
+
+        public Dictionary<string, string> GenerateExtraQueryParams()
+        {
+            return _queryParams;
+        }
+
+        public override string ToString()
+        {
+            return "RequestOptions{" +
+                   "headers=" + _headers +
+                   ", queryParams=" + _queryParams +
+                   ", forwardedFor='" + _forwardedFor + '\'' +
+                   '}';
+        }
+    }
+}

--- a/Algolia.Search/Models/RequestOptions.cs
+++ b/Algolia.Search/Models/RequestOptions.cs
@@ -9,6 +9,11 @@ namespace Algolia.Search.Models
         private readonly Dictionary<string, string> _queryParams = new Dictionary<string, string>();
         private string _forwardedFor;
 
+        public RequestOptions()
+        {
+            
+        }
+
         public RequestOptions SetForwardedFor(string forwardedFor)
         {
             _forwardedFor = forwardedFor;

--- a/Algolia.Search/Models/RuleQuery.cs
+++ b/Algolia.Search/Models/RuleQuery.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace Algolia.Search.Models
+{
+	public class RuleQuery
+	{
+		public RuleQuery()
+		{
+		}
+
+		public RuleQuery(string query, string anchoring, string context)
+		{
+			Query = query;
+			Anchoring = anchoring;
+			Context = context;
+		}
+
+		public RuleQuery(string query, string anchoring, string context, int page, int hitsPerPage)
+		{
+			Query = query;
+			Anchoring = anchoring;
+			Context = context;
+			Page = page;
+			HitsPerPage = hitsPerPage;
+		}
+
+		[JsonProperty(PropertyName = "query")]
+		public string Query { get; set; } = "";
+
+		[JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "anchoring")]
+		public string Anchoring { get; set; }
+
+		[JsonProperty(PropertyName = "context")]
+		public string Context { get; set; } = "";
+
+		[JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "page")]
+		public int? Page { get; set; }
+
+		[JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "hitsPerPage")]
+		public int? HitsPerPage { get; set; }
+	}
+}

--- a/Algolia.Search/Query.cs
+++ b/Algolia.Search/Query.cs
@@ -127,7 +127,7 @@ namespace Algolia.Search
         {
             Query q = new Query();
             q.advancedSyntax = advancedSyntax;
-	    q.removeStopWords = removeStopWords;
+            q.removeStopWords = removeStopWords;
             q.allowTyposOnNumericTokens = allowTyposOnNumericTokens;
             q.analytics = analytics;
             q.analyticsTags = analyticsTags;
@@ -157,7 +157,7 @@ namespace Algolia.Search
             q.optionalWords = optionalWords;
             q.page = page;
             q.query = query;
-	    q.similarQuery = similarQuery;
+            q.similarQuery = similarQuery;
             q.queryType = queryType;
             q.removeWordsIfNoResult = removeWordsIfNoResult;
             q.replaceSynonyms = replaceSynonyms;
@@ -169,6 +169,8 @@ namespace Algolia.Search
             q.aroundRadius = aroundRadius;
             q.aroundPrecision = aroundPrecision;
             q.customParameters = customParameters;
+            q.enableRules = enableRules;
+            q.ruleContexts = ruleContexts;
             return q;
         }
 
@@ -826,6 +828,29 @@ namespace Algolia.Search
             return this;
         }
 
+        /// <summary>
+        /// Allows enabling of rules.
+        /// </summary>
+        /// <param name="enabled">Turn it on or off</param>
+        /// <returns></returns>
+        public Query EnableRules(bool enabled)
+        {
+            this.enableRules = enabled;
+            return this;
+        }
+
+        /// <summary>
+        /// List of contexts for which rules are enabled.
+        /// Contextual rules matching any of these contexts are eligible, as well a s generic rules.
+        /// When empty, only generic rules are eligible.
+        /// </summary>
+        /// <param name="ruleContexts"></param>
+        /// <returns></returns>
+        public Query SetRuleContexts(IEnumerable<string> ruleContexts)
+        {
+            this.ruleContexts = ruleContexts;
+            return this;
+        }
 
         /// <summary>
         /// Allows enabling of stop words removal.
@@ -1177,6 +1202,27 @@ namespace Algolia.Search
                 stringBuilder += "advancedSyntax=";
                 stringBuilder += advancedSyntax.Value ? "1" : "0";
             }
+            if (enableRules.HasValue)
+            {
+                if (stringBuilder.Length > 0)
+                    stringBuilder += '&';
+                stringBuilder += "enableRules=";
+                stringBuilder += enableRules.Value ? "true" : "false";
+            }
+            if (ruleContexts != null)
+            {
+                if (stringBuilder.Length > 0)
+                    stringBuilder += '&';
+                stringBuilder += "ruleContexts=";
+                bool first = true;
+                foreach (string attr in this.ruleContexts)
+                {
+                    if (!first)
+                        stringBuilder += ',';
+                    stringBuilder += WebUtility.UrlEncode(attr);
+                    first = false;
+                }
+            }
             if (!String.IsNullOrEmpty(removeStopWords))
             {
                 if (stringBuilder.Length > 0)
@@ -1454,5 +1500,7 @@ namespace Algolia.Search
         private IEnumerable<string> restrictIndices;
         private string restrictSources;
         private string referers;
+        private bool? enableRules;
+        private IEnumerable<string> ruleContexts;
     }
 }

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 Changelog
 =========
+4.0.1-beta (2017-09-13)
+- Support for Rules.
+- Support for per-request options parameters. Warning: In this beta version, it will be source-code compatible but not binary compatible. In the stable version, we will fix that by adding overload methods.
 
 4.0 (2017-05-24)
 - Support to .NET Core 1.0 and 1.1, .Net Framework 4.6 and 4.6.2, .NETStandard 1.3 and 1.6

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,8 +1,9 @@
 Changelog
 =========
-4.0.1-beta (2017-09-13)
+4.0.1 (2017-09-13)
 - Support for Rules.
-- Support for per-request options parameters. Warning: In this beta version, it will be source-code compatible but not binary compatible. In the stable version, we will fix that by adding overload methods.
+- Support for per-request options parameters. 
+**Warning**: This version will be source-code compatible with the previous one but not binary compatible. In the next version, we will fix that by adding overload methods.
 
 4.0 (2017-05-24)
 - Support to .NET Core 1.0 and 1.1, .Net Framework 4.6 and 4.6.2, .NETStandard 1.3 and 1.6

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,9 @@
 Changelog
 =========
-4.0.1 (2017-09-13)
+4.1.1 (2017-09-13)
+- Adding overload methods everywhere to ensure binary compatibility with previous versions of the client. This is due to adding the RequestOptions optional parameter.
+
+4.1.0 (2017-09-13)
 - Support for Rules.
 - Support for per-request options parameters. 
 **Warning**: This version will be source-code compatible with the previous one but not binary compatible. In the next version, we will fix that by adding overload methods.


### PR DESCRIPTION
- Create RequestOptions class
- Change the way we send the http request from [client.{action}Async](https://github.com/algolia/algoliasearch-client-csharp/compare/request-options?expand=1#diff-3c0743ed790b438e879144d8670f9ea4L1109) to [client.sendAsync](https://github.com/algolia/algoliasearch-client-csharp/compare/request-options?expand=1#diff-3c0743ed790b438e879144d8670f9ea4R1150) in order to add extra headers. The reason is because we can't add custom headers per request when doing client.{Get/Post/Put/Delete}Asnyc.
- Add request options to all methods
- Tests work locally, issue is known about 2 tests not working on appveyor due to some key permission problem. @CBaptiste will take a look