### PR TITLE
fix: Prevent saving a rule with an empty objectID

### DIFF
--- a/Algolia.Search.Test/AlgoliaClientTest.cs
+++ b/Algolia.Search.Test/AlgoliaClientTest.cs
@@ -1135,6 +1135,25 @@ namespace Algolia.Search.Test
 			AreEqualByJson(rule, _index.GetRule(ruleId));
 		}
 
+        [Fact]
+        public void TestSaveRuleWithEmptyObjectID()
+        {
+            ClearTest();
+
+            string ruleID = "";
+            JObject rule = generateRuleStub(ruleID);
+            try
+            {
+                Assert.Throws<AlgoliaException>(() =>
+                {
+                    _index.SaveRule(rule);
+                });
+            }
+            catch (Exception)
+            {
+            }
+        }
+
 		[Fact]
 		public void TestDeleteRule()
 		{

--- a/Algolia.Search/Index.cs
+++ b/Algolia.Search/Index.cs
@@ -1680,6 +1680,12 @@ namespace Algolia.Search
 			}
 
 			string objectID = (string)queryRule["objectID"];
+
+			if (objectID.IsNullOrEmpty())
+			{
+			    throw new AlgoliaException("objectID cannot be empty");
+			}
+
 			return _client.ExecuteRequest(AlgoliaClient.callType.Write, "PUT", string.Format("/1/indexes/{0}/rules/{1}?forwardToReplicas={2}", _urlIndexName, WebUtility.UrlEncode(objectID), forwardToReplicas.ToString().ToLower()), queryRule, token, requestOptions);
 		}
 

--- a/Algolia.Search/Index.cs
+++ b/Algolia.Search/Index.cs
@@ -1681,7 +1681,7 @@ namespace Algolia.Search
 
 			string objectID = (string)queryRule["objectID"];
 
-			if (objectID.IsNullOrEmpty())
+			if (string.IsNullOrEmpty(objectID))
 			{
 			    throw new AlgoliaException("objectID cannot be empty");
 			}


### PR DESCRIPTION
Not sure if I missed to add some tests or even if it's the appropriate way of doing it. All comments are most welcome :)