### PR TITLE
fix(browse): Ensure cursor is passed in the body

### DIFF
--- a/Algolia.Search.Test/AlgoliaClientTest.cs
+++ b/Algolia.Search.Test/AlgoliaClientTest.cs
@@ -370,6 +370,27 @@ namespace Algolia.Search.Test
         }
 
         [Fact]
+        public void TestBrowseFrom()
+        {
+            ClearTest();
+
+            _index.AddObject(JObject.Parse(@"{""name"":""San Francisco"", ""objectID"":""1"", ""nickname"":""SF""}"));
+            var task = _index.AddObject(JObject.Parse(@"{""name"":""Los Angeles"", ""objectID"":""2"", ""nickname"":""SanF""}"));
+            _index.WaitTask(task["taskID"].ToString());
+            
+            var query = new Query().SetNbHitsPerPage(1);
+            var res = _index.BrowseAll(query);
+            
+            List<JObject> hits = new List<JObject>();
+            foreach (var hit in res)
+            {
+                hits.Add(hit);
+            }
+            
+            Assert.Equal(2, hits.Count);
+        }
+
+        [Fact]
         public void TestBrowse()
         {
             ClearTest();

--- a/Algolia.Search/Index.cs
+++ b/Algolia.Search/Index.cs
@@ -590,9 +590,13 @@ namespace Algolia.Search
             string cursorParam = "";
             if (cursor != null && cursor.Length > 0)
             {
-                cursorParam = string.Format("&cursor={0}", WebUtility.UrlEncode(cursor));
+                Dictionary<string, object> body = new Dictionary<string, object>();
+                body["cursor"] = cursor;
+
+                return _client.ExecuteRequest(AlgoliaClient.callType.Read, "POST", string.Format("/1/indexes/{0}/browse?{1}", _urlIndexName, q.GetQueryString()), body, token, requestOptions);
             }
-            return _client.ExecuteRequest(AlgoliaClient.callType.Read, "GET", string.Format("/1/indexes/{0}/browse?{1}{2}", _urlIndexName, q.GetQueryString(), cursorParam), null, token, requestOptions);
+
+            return _client.ExecuteRequest(AlgoliaClient.callType.Read, "GET", string.Format("/1/indexes/{0}/browse?{1}", _urlIndexName, q.GetQueryString()), null, token, requestOptions);
         }
 
         /// <summary>

--- a/Algolia.Search/Index.cs
+++ b/Algolia.Search/Index.cs
@@ -587,12 +587,11 @@ namespace Algolia.Search
         /// <param name="token"></param>
         public Task<JObject> BrowseFromAsync(Query q, string cursor, RequestOptions requestOptions, CancellationToken token = default(CancellationToken))
         {
-            string cursorParam = "";
             if (cursor != null && cursor.Length > 0)
             {
-                Dictionary<string, object> body = new Dictionary<string, object>();
-                body["cursor"] = cursor;
-
+                JObject body = new JObject(); 
+                body.Add("cursor", cursor);
+                
                 return _client.ExecuteRequest(AlgoliaClient.callType.Read, "POST", string.Format("/1/indexes/{0}/browse?{1}", _urlIndexName, q.GetQueryString()), body, token, requestOptions);
             }
 


### PR DESCRIPTION
Cursor can get very long and exceed the max url size, for that reason we always pass it in the body of the request.

Note: In case there is no params (if you use $query = null) we fallback on a GET call since the API doesn't allow empty bodies for POST.