### PR TITLE
Fixed: Browse Post URL

### DIFF
--- a/Algolia.Search/Index.cs
+++ b/Algolia.Search/Index.cs
@@ -592,7 +592,7 @@ namespace Algolia.Search
                 JObject body = new JObject(); 
                 body.Add("cursor", cursor);
                 
-                return _client.ExecuteRequest(AlgoliaClient.callType.Read, "POST", string.Format("/1/indexes/{0}/browse?{1}", _urlIndexName, q.GetQueryString()), body, token, requestOptions);
+                return _client.ExecuteRequest(AlgoliaClient.callType.Read, "POST", string.Format("/1/indexes/{0}/browse", _urlIndexName), body, token, requestOptions);
             }
 
             return _client.ExecuteRequest(AlgoliaClient.callType.Read, "GET", string.Format("/1/indexes/{0}/browse?{1}", _urlIndexName, q.GetQueryString()), null, token, requestOptions);


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Need Doc update   | no

## What problem is this fixing?

The URI regarding the browse method was not respecting the documentation : https://www.algolia.com/doc/rest-api/search/#browse-index-post
