### PR TITLE
Added: Move Method to Index class and deprecated Move on Client class

### DIFF
--- a/Algolia.Search.Test/AlgoliaClientTest.cs
+++ b/Algolia.Search.Test/AlgoliaClientTest.cs
@@ -1855,7 +1855,7 @@ namespace Algolia.Search.Test
         }
 
         [Fact]
-        public void TestNewMoveIndex()
+        public void TestMoveTo()
         {
             string originalIndex = "MoveIndex";
             string newIndex = "MoveIndex2";
@@ -1866,7 +1866,7 @@ namespace Algolia.Search.Test
             var addObjectTask = index.AddObject(new JObject { { "objectID", "test" } });
             index.WaitTask(addObjectTask["taskID"].ToString());
 
-            var moveTask = index.MoveIndex(newIndex);
+            var moveTask = index.MoveTo(newIndex);
             index.WaitTask(moveTask["taskID"].ToString());
 
             // should contain the new index and should not contain the old one

--- a/Algolia.Search/AlgoliaClient.cs
+++ b/Algolia.Search/AlgoliaClient.cs
@@ -315,6 +315,7 @@ namespace Algolia.Search
         /// <param name="dstIndexName">The new index name that will contain a copy of srcIndexName (destination will be overriten if it already exists).</param>
         /// <param name="requestOptions"></param>
         /// <param name="token"></param>
+        [Obsolete("Client.MoveIndex is deprecated, please use Index.MoveIndex instead")]
         public Task<JObject> MoveIndexAsync(string srcIndexName, string dstIndexName, RequestOptions requestOptions, CancellationToken token = default(CancellationToken))
         {
             Dictionary<string, object> operation = new Dictionary<string, object>();
@@ -329,6 +330,7 @@ namespace Algolia.Search
         /// <param name="srcIndexName">The name of index to move.</param>
         /// <param name="dstIndexName">The new index name that will contain a copy of srcIndexName (destination will be overriten if it already exists).</param>
         /// <param name="requestOptions"></param>
+        [Obsolete("Client.MoveIndex is deprecated, please use Index.MoveIndex instead")]
         public JObject MoveIndex(string srcIndexName, string dstIndexName, RequestOptions requestOptions)
         {
             return MoveIndexAsync(srcIndexName, dstIndexName, requestOptions, default(CancellationToken)).GetAwaiter().GetResult();

--- a/Algolia.Search/AlgoliaClient.cs
+++ b/Algolia.Search/AlgoliaClient.cs
@@ -315,7 +315,7 @@ namespace Algolia.Search
         /// <param name="dstIndexName">The new index name that will contain a copy of srcIndexName (destination will be overriten if it already exists).</param>
         /// <param name="requestOptions"></param>
         /// <param name="token"></param>
-        [Obsolete("Client.MoveIndex is deprecated, please use Index.MoveTo instead")]
+        [Obsolete("Client.MoveIndexAsync is deprecated, please use Index.MoveToAsync instead")]
         public Task<JObject> MoveIndexAsync(string srcIndexName, string dstIndexName, RequestOptions requestOptions, CancellationToken token = default(CancellationToken))
         {
             Dictionary<string, object> operation = new Dictionary<string, object>();

--- a/Algolia.Search/AlgoliaClient.cs
+++ b/Algolia.Search/AlgoliaClient.cs
@@ -315,7 +315,7 @@ namespace Algolia.Search
         /// <param name="dstIndexName">The new index name that will contain a copy of srcIndexName (destination will be overriten if it already exists).</param>
         /// <param name="requestOptions"></param>
         /// <param name="token"></param>
-        [Obsolete("Client.MoveIndex is deprecated, please use Index.MoveIndex instead")]
+        [Obsolete("Client.MoveIndex is deprecated, please use Index.MoveTo instead")]
         public Task<JObject> MoveIndexAsync(string srcIndexName, string dstIndexName, RequestOptions requestOptions, CancellationToken token = default(CancellationToken))
         {
             Dictionary<string, object> operation = new Dictionary<string, object>();
@@ -330,7 +330,7 @@ namespace Algolia.Search
         /// <param name="srcIndexName">The name of index to move.</param>
         /// <param name="dstIndexName">The new index name that will contain a copy of srcIndexName (destination will be overriten if it already exists).</param>
         /// <param name="requestOptions"></param>
-        [Obsolete("Client.MoveIndex is deprecated, please use Index.MoveIndex instead")]
+        [Obsolete("Client.MoveIndex is deprecated, please use Index.MoveTo instead")]
         public JObject MoveIndex(string srcIndexName, string dstIndexName, RequestOptions requestOptions)
         {
             return MoveIndexAsync(srcIndexName, dstIndexName, requestOptions, default(CancellationToken)).GetAwaiter().GetResult();

--- a/Algolia.Search/Index.cs
+++ b/Algolia.Search/Index.cs
@@ -2011,5 +2011,35 @@ namespace Algolia.Search
         public JObject BatchRules(IEnumerable<JObject> queryRules, bool forwardToReplicas = false, bool clearExistingRules = false)
         { return BatchRules(queryRules, null, forwardToReplicas, clearExistingRules); }
 
+        /// <summary>
+        /// Move this exisint index to a new one.
+        /// </summary>
+        /// <param name="dstIndexName">The new index name that will contain a copy of this index.</param>
+        /// <param name="requestOptions"></param>
+        /// <param name="token"></param>
+        public Task<JObject> MoveIndexAsync(string dstIndexName, RequestOptions requestOptions = null, CancellationToken token = default(CancellationToken))
+        {
+            Dictionary<string, object> operation = new Dictionary<string, object>();
+            operation["operation"] = "move";
+            operation["destination"] = dstIndexName;
+
+            var response = _client.ExecuteRequest(AlgoliaClient.callType.Write, "POST", string.Format("/1/indexes/{0}/operation", _urlIndexName), operation, token, requestOptions);
+            
+            _indexName = dstIndexName;
+            _urlIndexName = WebUtility.UrlEncode(_indexName);
+
+            return response;
+        }
+
+        /// <summary>
+        /// Synchronously call <see cref="AlgoliaClient.MoveIndexAsync"/>
+        /// </summary>
+        /// <param name="dstIndexName">The new index name that will contain a copy of srcIndexName (destination will be overriten if it already exists).</param>
+        /// <param name="requestOptions"></param>
+        public JObject MoveIndex(string dstIndexName, RequestOptions requestOptions = null)
+        {
+            return MoveIndexAsync(dstIndexName, requestOptions, default(CancellationToken)).GetAwaiter().GetResult();
+        }
+
     }
 }

--- a/Algolia.Search/Index.cs
+++ b/Algolia.Search/Index.cs
@@ -2012,12 +2012,12 @@ namespace Algolia.Search
         { return BatchRules(queryRules, null, forwardToReplicas, clearExistingRules); }
 
         /// <summary>
-        /// Move this exisint index to a new one.
+        /// Move this existing index to a new one.
         /// </summary>
         /// <param name="dstIndexName">The new index name that will contain a copy of this index.</param>
         /// <param name="requestOptions"></param>
         /// <param name="token"></param>
-        public Task<JObject> MoveIndexAsync(string dstIndexName, RequestOptions requestOptions = null, CancellationToken token = default(CancellationToken))
+        public Task<JObject> MoveToAsync(string dstIndexName, RequestOptions requestOptions = null, CancellationToken token = default(CancellationToken))
         {
             Dictionary<string, object> operation = new Dictionary<string, object>();
             operation["operation"] = "move";
@@ -2036,9 +2036,9 @@ namespace Algolia.Search
         /// </summary>
         /// <param name="dstIndexName">The new index name that will contain a copy of srcIndexName (destination will be overriten if it already exists).</param>
         /// <param name="requestOptions"></param>
-        public JObject MoveIndex(string dstIndexName, RequestOptions requestOptions = null)
+        public JObject MoveTo(string dstIndexName, RequestOptions requestOptions = null)
         {
-            return MoveIndexAsync(dstIndexName, requestOptions, default(CancellationToken)).GetAwaiter().GetResult();
+            return MoveToAsync(dstIndexName, requestOptions, default(CancellationToken)).GetAwaiter().GetResult();
         }
 
     }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no     
| Need Doc update   | ye


## Describe your change
This PR adds the move method to the Index class.
`index.MoveIndex("newIndex");`

This PR also depreciates the move method of the client class
`client.MoveIndex("oldIndex", "newIndex");`