### PR TITLE
Expose the raw HttpStatusCode on the AlgoliaException object.

### DIFF
--- a/Algolia.Search/AlgoliaClient.cs
+++ b/Algolia.Search/AlgoliaClient.cs
@@ -1005,7 +1005,7 @@ namespace Algolia.Search
                                 status = obj["status"].ToString();
                                 if (obj["status"].ToObject<int>() / 100 == 4)
                                 {
-                                    throw new AlgoliaException(message);
+                                    throw new AlgoliaException(message, responseMsg.StatusCode);
                                 }
                             }
                             catch (JsonReaderException)

--- a/Algolia.Search/AlgoliaException.cs
+++ b/Algolia.Search/AlgoliaException.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net;
 
 namespace Algolia.Search
 {
@@ -7,13 +8,16 @@ namespace Algolia.Search
     /// </summary>
     public class AlgoliaException : Exception
     {
+        public HttpStatusCode? HttpStatusCode { get; }
+
         /// <summary>
         /// Create a new Algolia exception.
         /// </summary>
         /// <param name="message">The exception details.</param>
-        public AlgoliaException(string message) : base(message)
+        /// <param name="httpStatusCode">The raw HttpStatusCode</param>
+        public AlgoliaException(string message, HttpStatusCode? httpStatusCode = null) : base(message)
         {
-
+            HttpStatusCode = httpStatusCode;
         }
     }
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no     
| Related Issue     | Fix #525
| Need Doc update   | no


## Describe your change

Expose the raw HttpStatusCode on the algoliaException, making it possible to compare to 429 in the case of rate limit. Another way would be to wrap this in a subclass of AlgoliaException, e.g. AlgoliaRateLimitException.

## What problem is this fixing?

Makes it possible to find out if we're currently rate limited.
