### PR TITLE
Fixed: EnsuredObjectID not working with POCO base class

### DIFF
--- a/src/Algolia.Search.Test/EndToEnd/Index/IndexingTest.cs
+++ b/src/Algolia.Search.Test/EndToEnd/Index/IndexingTest.cs
@@ -280,9 +280,13 @@ namespace Algolia.Search.Test.EndToEnd.Index
         }
     }
 
-    public class AlgoliaStub
+    public class AlgoliaObject
     {
         public string ObjectID { get; set; }
+    }
+
+    public class AlgoliaStub : AlgoliaObject
+    {
         public string Property { get; set; } = "Default";
         [JsonProperty(PropertyName = "_tags")]
         public List<string> Tags { get; set; }

--- a/src/Algolia.Search.Test/EndToEnd/Index/IndexingTest.cs
+++ b/src/Algolia.Search.Test/EndToEnd/Index/IndexingTest.cs
@@ -70,7 +70,7 @@ namespace Algolia.Search.Test.EndToEnd.Index
         public async Task IndexOperationsAsyncTest()
         {
             // AddObject with ID
-            var objectOne = new AlgoliaStub { ObjectID = "one" };
+            var objectOne = new AlgoliaStub { ObjectId = "one" };
             var addObject = _index.SaveObjectAsync(objectOne);
 
             // AddObject without ID
@@ -80,8 +80,8 @@ namespace Algolia.Search.Test.EndToEnd.Index
             // Save two objects with objectID
             var objectsWithIds = new List<AlgoliaStub>
             {
-                new AlgoliaStub {ObjectID = "two"},
-                new AlgoliaStub {ObjectID = "three"}
+                new AlgoliaStub {ObjectId = "two"},
+                new AlgoliaStub {ObjectId = "three"}
             };
 
             var addObjects = _index.SaveObjectsAsync(objectsWithIds);
@@ -102,7 +102,7 @@ namespace Algolia.Search.Test.EndToEnd.Index
             for (int i = 0; i < 1000; i++)
             {
                 var id = (i + 1).ToString();
-                objectsToBatch.Add(new AlgoliaStub { ObjectID = id, Property = $"Property{id}" });
+                objectsToBatch.Add(new AlgoliaStub { ObjectId = id, Property = $"Property{id}" });
                 ids.Add(id);
             }
 
@@ -116,11 +116,11 @@ namespace Algolia.Search.Test.EndToEnd.Index
 
             // Six first records
             var generatedId = addObjectWoId.Result.Responses[0].ObjectIDs.ToList();
-            objectWoId.ObjectID = generatedId.ElementAt(0);
+            objectWoId.ObjectId = generatedId.ElementAt(0);
 
             var generatedIDs = addObjectsWoId.Result.Responses[0].ObjectIDs.ToList();
-            objectsWoId[0].ObjectID = generatedIDs.ElementAt(0);
-            objectsWoId[1].ObjectID = generatedIDs.ElementAt(1);
+            objectsWoId[0].ObjectId = generatedIDs.ElementAt(0);
+            objectsWoId[1].ObjectId = generatedIDs.ElementAt(1);
 
             var settedIds = new List<string> { "one", "two", "three" };
 
@@ -164,7 +164,7 @@ namespace Algolia.Search.Test.EndToEnd.Index
             var partialUpdateObject = await _index.PartialUpdateObjectAsync(objectToPartialUpdate);
             partialUpdateObject.Wait();
 
-            var getUpdatedObject = await _index.GetObjectAsync<AlgoliaStub>(objectToPartialUpdate.ObjectID);
+            var getUpdatedObject = await _index.GetObjectAsync<AlgoliaStub>(objectToPartialUpdate.ObjectId);
             Assert.True(getUpdatedObject.Property.Equals(objectToPartialUpdate.Property));
 
             // Update two objects
@@ -183,8 +183,8 @@ namespace Algolia.Search.Test.EndToEnd.Index
 
             var getUpdatedObjects = (await _index.GetObjectsAsync<AlgoliaStub>(new List<string>
             {
-                objectToPartialUpdate1.ObjectID,
-                objectToPartialUpdate2.ObjectID
+                objectToPartialUpdate1.ObjectId,
+                objectToPartialUpdate2.ObjectId
             })).ToList();
 
             Assert.True(getUpdatedObjects.ElementAt(0).Property.Equals(objectToPartialUpdate1.Property));
@@ -220,7 +220,7 @@ namespace Algolia.Search.Test.EndToEnd.Index
             for (int i = 0; i < 10; i++)
             {
                 var id = (i + 1).ToString();
-                objectsToBatch.Add(new AlgoliaStub { ObjectID = id, Tags = new List<string> { "car" } });
+                objectsToBatch.Add(new AlgoliaStub { ObjectId = id, Tags = new List<string> { "car" } });
                 ids.Add(id);
             }
 
@@ -246,7 +246,7 @@ namespace Algolia.Search.Test.EndToEnd.Index
             for (int i = 0; i < 10; i++)
             {
                 var id = (i + 1).ToString();
-                objectsToBatch.Add(new AlgoliaStub { ObjectID = id, Tags = new List<string> { "car" } });
+                objectsToBatch.Add(new AlgoliaStub { ObjectId = id, Tags = new List<string> { "car" } });
                 ids.Add(id);
             }
 
@@ -264,7 +264,7 @@ namespace Algolia.Search.Test.EndToEnd.Index
         [Parallelizable]
         public async Task MoveIndexTest()
         {
-            var objectOne = new AlgoliaStub { ObjectID = "one" };
+            var objectOne = new AlgoliaStub { ObjectId = "one" };
             var addObject = await _indexMove.SaveObjectAsync(objectOne);
 
             addObject.Wait();
@@ -282,7 +282,8 @@ namespace Algolia.Search.Test.EndToEnd.Index
 
     public class AlgoliaObject
     {
-        public string ObjectID { get; set; }
+        [JsonProperty(PropertyName = "objectID")]
+        public string ObjectId { get; set; }
     }
 
     public class AlgoliaStub : AlgoliaObject

--- a/src/Algolia.Search/Utils/AlgoliaHelper.cs
+++ b/src/Algolia.Search/Utils/AlgoliaHelper.cs
@@ -25,6 +25,7 @@ using Algolia.Search.Exceptions;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 
@@ -88,6 +89,22 @@ namespace Algolia.Search.Utils
         }
 
         /// <summary>
+        /// Get all properties of a type (including base class)
+        /// </summary>
+        /// <param name="T"></param>
+        public static IEnumerable<PropertyInfo> GetAllProperties(Type T)
+        {
+            IEnumerable<PropertyInfo> PropertyList = T.GetTypeInfo().DeclaredProperties;
+
+            if (T.GetTypeInfo().BaseType != null)
+            {
+                PropertyList = PropertyList.Concat(GetAllProperties(T.GetTypeInfo().BaseType));
+            }
+
+            return PropertyList;
+        }
+
+        /// <summary>
         /// Check if the Property or JsonPropertyAttribute exists in the given type, return null if not exist otherwise return propertyInfo
         /// </summary>
         /// <typeparam name="T">Type of the data to send/retrieve</typeparam>
@@ -96,7 +113,7 @@ namespace Algolia.Search.Utils
         private static PropertyInfo PropertyOrJsonAttributeExists<T>(string propertyName)
         {
             var typeInfo = typeof(T).GetTypeInfo();
-            var declaredProperties = typeInfo.DeclaredProperties;
+            var declaredProperties = GetAllProperties(typeof(T));
 
             var objectIdProperty = declaredProperties.FirstOrDefault(p => p.Name.Equals(propertyName));
 

--- a/src/Algolia.Search/Utils/AlgoliaHelper.cs
+++ b/src/Algolia.Search/Utils/AlgoliaHelper.cs
@@ -124,10 +124,10 @@ namespace Algolia.Search.Utils
 
             var camelCaseProperty = CamelCaseHelper.ToCamelCase(propertyName);
 
-            if (typeInfo.GetCustomAttribute<JsonPropertyAttribute>() != null)
+            if (declaredProperties.Any(x => x.GetCustomAttribute<JsonPropertyAttribute>() != null))
             {
-                return declaredProperties.FirstOrDefault(p =>
-                    p.GetCustomAttribute<JsonPropertyAttribute>().PropertyName.Equals(camelCaseProperty));
+                var propertiesWithJsonPropertyattributes = declaredProperties.Where(p => p.GetCustomAttribute<JsonPropertyAttribute>() != null);
+                return propertiesWithJsonPropertyattributes.FirstOrDefault(p => p.GetCustomAttribute<JsonPropertyAttribute>().PropertyName.Contains(camelCaseProperty));
             }
 
             return null;

--- a/src/Algolia.Search/Utils/AlgoliaHelper.cs
+++ b/src/Algolia.Search/Utils/AlgoliaHelper.cs
@@ -127,7 +127,7 @@ namespace Algolia.Search.Utils
             if (declaredProperties.Any(x => x.GetCustomAttribute<JsonPropertyAttribute>() != null))
             {
                 var propertiesWithJsonPropertyattributes = declaredProperties.Where(p => p.GetCustomAttribute<JsonPropertyAttribute>() != null);
-                return propertiesWithJsonPropertyattributes.FirstOrDefault(p => p.GetCustomAttribute<JsonPropertyAttribute>().PropertyName.Contains(camelCaseProperty));
+                return propertiesWithJsonPropertyattributes.FirstOrDefault(p => p.GetCustomAttribute<JsonPropertyAttribute>().PropertyName.Equals(camelCaseProperty));
             }
 
             return null;


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     |  #536 #539 
| Need Doc update   | no

## What problem is this fixing?

An error when using `SaveObjects` with a POCO that have `ObjectID` in a base class.

## Describe your change

Added a `GetAllProperties` method in `AlgoliaHelper` that is able to check that a base class has a `
ObjectID` property.


