### PR TITLE
Fixed: deleteObject wrong URI

### DIFF
--- a/src/Algolia.Search.Test/EndToEnd/Index/IndexingTest.cs
+++ b/src/Algolia.Search.Test/EndToEnd/Index/IndexingTest.cs
@@ -230,6 +230,9 @@ namespace Algolia.Search.Test.EndToEnd.Index
             var delete = await _indexDeleteBy.DeleteObjectAsync("1");
             delete.Wait();
 
+            var searchAfterDelete = await _indexDeleteBy.SearchAsync<AlgoliaStub>(new Query(""));
+            Assert.True(searchAfterDelete.Hits.Count == 9);
+
             var resp = await _indexDeleteBy.DeleteByAsync(new Query { TagFilters = "car" });
             resp.Wait();
 

--- a/src/Algolia.Search/Clients/SearchIndex.cs
+++ b/src/Algolia.Search/Clients/SearchIndex.cs
@@ -328,8 +328,8 @@ namespace Algolia.Search.Clients
                 throw new ArgumentNullException(nameof(objectId));
             }
 
-            DeleteResponse response = await _transport.ExecuteRequestAsync<DeleteResponse>(HttpMethod.Get,
-                    $"/1/indexes/{_urlEncodedIndexName}/{objectId}", CallType.Read, requestOptions, ct)
+            DeleteResponse response = await _transport.ExecuteRequestAsync<DeleteResponse>(HttpMethod.Delete,
+                    $"/1/indexes/{_urlEncodedIndexName}/{objectId}", CallType.Write, requestOptions, ct)
                 .ConfigureAwait(false);
 
             response.WaitTask = t => WaitTask(t);


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | Fix #535 
| Need Doc update   | yes/no


## Describe your change

Fixed `DeleteObject` URI.

## What problem is this fixing?

`DeleteObject` not working as expected.
