### PR TITLE
Fixed: calltype (read -> write) of SendEvents

### DIFF
--- a/src/Algolia.Search/Clients/InsightsClient.cs
+++ b/src/Algolia.Search/Clients/InsightsClient.cs
@@ -130,7 +130,7 @@ namespace Algolia.Search.Clients
             var request = new InsightsRequest {Events = insightEvents};
 
             return await _transport.ExecuteRequestAsync<InsightsResponse, InsightsRequest>(HttpMethod.Post,
-                    "/1/events", CallType.Read, request, requestOptions, ct)
+                    "/1/events", CallType.Write, request, requestOptions, ct)
                 .ConfigureAwait(false);
         }
     }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| BC breaks?        | no     
| Related Issue     | Fix #546 
| Need Doc update   | no


## Describe your change
Fixed the CallType of `SendEvents`. From read to write.