### PR TITLE
Fixed: JsonPropertyName of SearchForFacetRequest

### DIFF
--- a/src/Algolia.Search/Models/Search/SearchForFacetRequest.cs
+++ b/src/Algolia.Search/Models/Search/SearchForFacetRequest.cs
@@ -21,6 +21,7 @@
 * THE SOFTWARE.
 */
 
+using Algolia.Search.Serializer;
 using Newtonsoft.Json;
 
 namespace Algolia.Search.Models.Search
@@ -46,7 +47,8 @@ namespace Algolia.Search.Models.Search
         /// <summary>
         /// Search parameters to be used to search the underlying index
         /// </summary>
-        [JsonProperty(PropertyName = "requests")]
+        [JsonProperty(PropertyName = "params")]
+        [JsonConverter(typeof(QuerySerializer))]
         public Query SearchParameters { get; set; }
     }
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | Fix #547 
| Need Doc update   | no

## Describe your change

The `SearchParameters` property in `SearchForFacetRequest` should have a `[JsonProperty(PropertyName = "params")]` instead of ` [JsonProperty(PropertyName = "requests")]`.

[Doc link.](https://www.algolia.com/doc/rest-api/search/?language=php#method-param-params-2)
