### PR TITLE
Fixing: package logo URL

### DIFF
--- a/src/Algolia.Search/Algolia.Search.csproj
+++ b/src/Algolia.Search/Algolia.Search.csproj
@@ -8,7 +8,7 @@
     <PackageId>Algolia.Search</PackageId>
     <PackageTags>Algolia;Search;SearchEngine;Service;Instant;Typo-Tolerance;Realtime;Analytics</PackageTags>
     <PackageReleaseNotes>https://github.com/algolia/algoliasearch-client-csharp/blob/master/ChangeLog</PackageReleaseNotes>
-    <PackageIconUrl>https://www.algolia.com/static/algolia-blue-mark-d9c78960c0c19f25f2dc0614236bff90.png</PackageIconUrl>
+    <PackageIconUrl>https://s.gravatar.com/avatar/ef38ca989ef6a4a6373435c257373b84?s=80</PackageIconUrl>
     <PackageProjectUrl>https://www.algolia.com/doc/api-client/getting-started/install/csharp/</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/algolia/algoliasearch-client-csharp</RepositoryUrl>

--- a/src/Algolia.Search/Algolia.Search.csproj
+++ b/src/Algolia.Search/Algolia.Search.csproj
@@ -8,7 +8,7 @@
     <PackageId>Algolia.Search</PackageId>
     <PackageTags>Algolia;Search;SearchEngine;Service;Instant;Typo-Tolerance;Realtime;Analytics</PackageTags>
     <PackageReleaseNotes>https://github.com/algolia/algoliasearch-client-csharp/blob/master/ChangeLog</PackageReleaseNotes>
-    <PackageIconUrl>https://www.algolia.com/static_assets/images/press/downloads/algolia-mark-blue.png</PackageIconUrl>
+    <PackageIconUrl>https://www.algolia.com/static/algolia-blue-mark-d9c78960c0c19f25f2dc0614236bff90.png</PackageIconUrl>
     <PackageProjectUrl>https://www.algolia.com/doc/api-client/getting-started/install/csharp/</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/algolia/algoliasearch-client-csharp</RepositoryUrl>


### PR DESCRIPTION
Updated the logo URL because the actual one is now returning a 404 since static website update.
@aseure Any idea if we could get back the old URL back? I need to upload a new minor version of the package to upload the link.