### PR TITLE
Removed: Wait() method for MCM

### DIFF
--- a/src/Algolia.Search/Clients/SearchClient.cs
+++ b/src/Algolia.Search/Clients/SearchClient.cs
@@ -466,26 +466,10 @@ namespace Algolia.Search.Clients
             var userIdHeader = new Dictionary<string, string>() { { "X-Algolia-USER-ID", userId } };
             requestOptions = requestOptions.AddHeaders(userIdHeader);
 
-            try
-            {
-                RemoveUserIdResponse response = await _transport.ExecuteRequestAsync<RemoveUserIdResponse>(
-                        HttpMethod.Delete,
-                        $"/1/clusters/mapping", CallType.Write, requestOptions, ct)
-                    .ConfigureAwait(false);
-
-                response.UserId = userId;
-                response.RemoveUserId = u => RemoveUserId(u);
-                return response;
-            }
-            catch (AlgoliaApiException ex)
-            {
-                if (!ex.Message.Contains("Another mapping operation is already running for this userID"))
-                {
-                    throw;
-                }
-
-                return new RemoveUserIdResponse { UserId = userId, RemoveUserId = u => RemoveUserId(u) };
-            }
+            return await _transport.ExecuteRequestAsync<RemoveUserIdResponse>(
+                    HttpMethod.Delete,
+                    $"/1/clusters/mapping", CallType.Write, requestOptions, ct)
+                .ConfigureAwait(false);
         }
 
         /// <inheritdoc />

--- a/src/Algolia.Search/Models/Mcm/AssignUserIdResponse.cs
+++ b/src/Algolia.Search/Models/Mcm/AssignUserIdResponse.cs
@@ -31,7 +31,7 @@ namespace Algolia.Search.Models.Mcm
     /// <summary>
     /// Waitable response of assignUserid method
     /// </summary>
-    public class AssignUserIdResponse : IAlgoliaWaitableResponse
+    public class AssignUserIdResponse
     {
         internal Func<string, UserIdResponse> GetUserId { get; set; }
 
@@ -41,36 +41,8 @@ namespace Algolia.Search.Models.Mcm
         public string UserId { get; set; }
 
         /// <summary>
-        /// Date of creation of the userId
+        /// /// Date of creation of the userId
         /// </summary>
         public DateTime CreatedAt { get; set; }
-
-        /// <summary>
-        /// Wait until the userID is created on the API
-        /// Loop until httpErrorCode != 404
-        /// </summary>
-        public void Wait()
-        {
-            while (true)
-            {
-                try
-                {
-                    GetUserId(UserId);
-                }
-                catch (AlgoliaApiException ex)
-                {
-                    // Loop until we have found the userID
-                    if (ex.HttpErrorCode == 404)
-                    {
-                        Task.Delay(1000);
-                        continue;
-                    }
-
-                    throw;
-                }
-
-                break;
-            }
-        }
     }
 }

--- a/src/Algolia.Search/Models/Mcm/AssignUserIdResponse.cs
+++ b/src/Algolia.Search/Models/Mcm/AssignUserIdResponse.cs
@@ -41,7 +41,7 @@ namespace Algolia.Search.Models.Mcm
         public string UserId { get; set; }
 
         /// <summary>
-        /// /// Date of creation of the userId
+        /// Date of creation of the userId
         /// </summary>
         public DateTime CreatedAt { get; set; }
     }

--- a/src/Algolia.Search/Models/Mcm/RemoveUserIdResponse.cs
+++ b/src/Algolia.Search/Models/Mcm/RemoveUserIdResponse.cs
@@ -31,7 +31,7 @@ namespace Algolia.Search.Models.Mcm
     /// <summary>
     /// Waitable response for removeUserId
     /// </summary>
-    public class RemoveUserIdResponse : IAlgoliaWaitableResponse
+    public class RemoveUserIdResponse
     {
         internal Func<string, RemoveUserIdResponse> RemoveUserId { get; set; }
 
@@ -44,36 +44,5 @@ namespace Algolia.Search.Models.Mcm
         /// Date of deletion
         /// </summary>
         public DateTime DeletedAt { get; set; }
-
-        /// <summary>
-        /// As the delete operation is asynchronous
-        /// Wait until the userId is deleted on the API
-        /// </summary>
-        public void Wait()
-        {
-            RemoveUserIdResponse deleteResponse;
-
-            while (true)
-            {
-                try
-                {
-                    deleteResponse = RemoveUserId(UserId);
-                }
-                catch (AlgoliaApiException ex)
-                {
-                    // Loop until we don't have Error 400: "Another mapping operation is already running for this userID"
-                    if (ex.Message.Contains("Another mapping operation is already running for this userID"))
-                    {
-                        Task.Delay(1000);
-                        continue;
-                    }
-
-                    throw;
-                }
-
-                DeletedAt = deleteResponse.DeletedAt;
-                break;
-            }
-        }
     }
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | #564 
| BC breaks?        | no     
| Need Doc update   | yes/no


## Describe your change

The Wait() helper method for MCM was not reliable enough, so with the team we decided to remove it.