### PR TITLE
Added: missing userToken parameter in Query

### DIFF
--- a/src/Algolia.Search/Models/Search/Query.cs
+++ b/src/Algolia.Search/Models/Search/Query.cs
@@ -356,6 +356,13 @@ namespace Algolia.Search.Models.Search
         public bool? GetRankingInfo { get; set; }
 
         /// <summary>
+        /// A user identifier.
+        /// Format: alpha numeric string [a-zA-Z0-9_-]
+        /// Length: between 1 and 64 characters.
+        /// </summary>
+        public string UserToken { get; set; }
+
+        /// <summary>
         /// Returns the Query as a query string 
         /// Example : "query= distinct=0"
         /// </summary>


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no     
| Need Doc update   | no


## Describe your change
Adding missing `userToken` parameter in the `Query` class.
