### PR TITLE
Added: custom parameters to Query and Settings

### DIFF
--- a/src/Algolia.Search.Test/EndToEnd/Index/SettingsTest.cs
+++ b/src/Algolia.Search.Test/EndToEnd/Index/SettingsTest.cs
@@ -135,7 +135,7 @@ namespace Algolia.Search.Test.EndToEnd.Index
             saveSettingsResponse.Wait();
 
             var getSettingsResponse = await _index.GetSettingsAsync();
-            var spceficPropertiesCheck = new List<string> { "AlternativesAsExact", "DecompoundedAttributes" };
+            var spceficPropertiesCheck = new List<string> { "AlternativesAsExact", "DecompoundedAttributes", "CustomSettings" };
             Assert.True(TestHelper.AreObjectsEqual(settings, getSettingsResponse, spceficPropertiesCheck.ToArray()));
 
             // Check specific properties (couldn't be done by the helper)

--- a/src/Algolia.Search.Test/Serializer/SerializerTest.cs
+++ b/src/Algolia.Search.Test/Serializer/SerializerTest.cs
@@ -114,6 +114,15 @@ namespace Algolia.Search.Test.Serializer
 
         [Test]
         [Parallelizable]
+        public void TestQueryWithCustomParameters()
+        {
+            Query query = new Query("algolia") { CustomParameters = new Dictionary<string, object> { { "newParameter", 10 } } };
+            string json = JsonConvert.SerializeObject(query, JsonConfig.AlgoliaJsonSerializerSettings);
+            Assert.AreEqual(json, "{\"query\":\"algolia\",\"newParameter\":10}");
+        }
+
+        [Test]
+        [Parallelizable]
         public void TestAutomaticFacetFilters()
         {
             string json = "[\"lastname\",\"firstname\"]";
@@ -191,6 +200,20 @@ namespace Algolia.Search.Test.Serializer
             Assert.IsNotNull(settings.NumericAttributesForFiltering);
             Assert.True(settings.NumericAttributesForFiltering.Contains("attr1"));
             Assert.True(settings.NumericAttributesForFiltering.Contains("attr2"));
+        }
+
+        [Test]
+        [Parallelizable]
+        public void TestIndexSettingsWithCustomParameters()
+        {
+            IndexSettings settings = new IndexSettings
+            {
+                EnableRules = true,
+                CustomSettings = new Dictionary<string, object> { { "newParameter", 10 } }
+            };
+
+            string json = JsonConvert.SerializeObject(settings, JsonConfig.AlgoliaJsonSerializerSettings);
+            Assert.AreEqual(json, "{\"enableRules\":true,\"newParameter\":10}");
         }
 
         [Test]

--- a/src/Algolia.Search/Models/Search/Query.cs
+++ b/src/Algolia.Search/Models/Search/Query.cs
@@ -377,6 +377,12 @@ namespace Algolia.Search.Models.Search
         public string UserToken { get; set; }
 
         /// <summary>
+        /// Custom parameters for advanced use cases
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> CustomParameters { get; set; }
+
+        /// <summary>
         /// Returns the Query as a query string
         /// Example : "query= distinct=0"
         /// </summary>

--- a/src/Algolia.Search/Models/Settings/IndexSettings.cs
+++ b/src/Algolia.Search/Models/Settings/IndexSettings.cs
@@ -325,6 +325,6 @@ namespace Algolia.Search.Models.Settings
         /// Custom settings for advanced use cases
         /// </summary>
         [JsonExtensionData]
-        public IDictionary<string, object> CustomSettings;
+        public IDictionary<string, object> CustomSettings { get; set; }
     }
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no     
| Need Doc update   | no

## Describe your change

Adds the possibility to the users to add custom parameters to `Query` and `IndexSettings`.