### PR TITLE
feat(index): add exists method

### DIFF
--- a/src/Algolia.Search.Test/EndToEnd/Index/ExistsTest.cs
+++ b/src/Algolia.Search.Test/EndToEnd/Index/ExistsTest.cs
@@ -1,0 +1,58 @@
+/*
+* Copyright (c) 2018 Algolia
+* http://www.algolia.com/
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+
+using Algolia.Search.Clients;
+using NUnit.Framework;
+using System.Threading.Tasks;
+
+namespace Algolia.Search.Test.EndToEnd.Index
+{
+    [TestFixture]
+    [Parallelizable]
+    public class ExistsTest
+    {
+        private SearchIndex _index;
+
+        [OneTimeSetUp]
+        public void Init()
+        {
+            _index = BaseTest.SearchClient.InitIndex(TestHelper.GetTestIndexName("exists"));
+        }
+
+        [Test]
+        public async Task TestExists()
+        {
+            var existsResponse = await _index.ExistsAsync();
+
+            Assert.False(existsResponse);
+
+            var saveObjectResponse = await _index.SaveObjectAsync(new { ObjectID = "one" });
+
+            saveObjectResponse.Wait();
+
+            var existsResponseAfterSave = await _index.ExistsAsync();
+
+            Assert.True(existsResponseAfterSave);
+        }
+    }
+}

--- a/src/Algolia.Search/Clients/ISearchIndex.cs
+++ b/src/Algolia.Search/Clients/ISearchIndex.cs
@@ -832,5 +832,18 @@ namespace Algolia.Search.Clients
         /// <returns></returns>
         Task<TaskStatusResponse> GetTaskAsync(long taskId, RequestOptions requestOptions = null,
             CancellationToken ct = default);
+
+        /// <summary>
+        /// Return whether an index exists or not
+        /// </summary>
+        /// <returns></returns>
+        bool Exists();
+
+        /// <summary>
+        /// Return whether an index exists or not
+        /// </summary>
+        /// <param name="ct">Optional cancellation token</param>
+        /// <returns></returns>
+        Task<bool> ExistsAsync(CancellationToken ct = default);
     }
 }

--- a/src/Algolia.Search/Clients/SearchIndex.cs
+++ b/src/Algolia.Search/Clients/SearchIndex.cs
@@ -21,6 +21,7 @@
 * THE SOFTWARE.
 */
 
+using Algolia.Search.Exceptions;
 using Algolia.Search.Http;
 using Algolia.Search.Iterators;
 using Algolia.Search.Models.Batch;
@@ -1060,6 +1061,23 @@ namespace Algolia.Search.Clients
             return await _transport.ExecuteRequestAsync<TaskStatusResponse>(HttpMethod.Get,
                     $"/1/indexes/{_urlEncodedIndexName}/task/{taskId}", CallType.Read, requestOptions, ct)
                 .ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public bool Exists() => AsyncHelper.RunSync(() => ExistsAsync());
+
+        /// <inheritdoc />
+        public async Task<bool> ExistsAsync(CancellationToken ct = default)
+        {
+            try
+            {
+                await GetSettingsAsync(ct: ct);
+            }
+            catch (AlgoliaApiException ex) when (ex.HttpErrorCode == 404)
+            {
+                return await Task.FromResult<bool>(false);
+            }
+            return await Task.FromResult<bool>(true);
         }
     }
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | Fix #625  <!-- will close issue automatically, if any -->
| Need Doc update   | yes

This adds the `SearchIndex.Exists` method in the client. It follows the [spec](https://github.com/algolia/algoliasearch-client-specs/blob/master/features/index-exists.md) and [common test suite](https://github.com/algolia/algoliasearch-client-specs/tree/master/common-test-suite#Exists).