### PR TITLE
fix: fix typo (WriteTimeut → WriteTimeout)

### DIFF
--- a/src/Algolia.Search/Transport/HttpTransport.cs
+++ b/src/Algolia.Search/Transport/HttpTransport.cs
@@ -196,10 +196,10 @@ namespace Algolia.Search.Transport
                     return _algoliaConfig.ReadTimeout ?? Defaults.ReadTimeout;
 
                 case CallType.Write:
-                    return _algoliaConfig.WriteTimeout ?? Defaults.WriteTimeut;
+                    return _algoliaConfig.WriteTimeout ?? Defaults.WriteTimeout;
 
                 default:
-                    return Defaults.WriteTimeut;
+                    return Defaults.WriteTimeout;
             }
         }
     }

--- a/src/Algolia.Search/Utils/Defaults.cs
+++ b/src/Algolia.Search/Utils/Defaults.cs
@@ -39,7 +39,7 @@ internal class Defaults
     /// <summary>
     /// Write timeout in seconds
     /// </summary>
-    public const int WriteTimeut = 30;
+    public const int WriteTimeout = 30;
     public const string AcceptHeader = "Accept";
     public const string AlgoliaApplicationHeader = "X-Algolia-Application-Id";
     public const string AlgoliaApiKeyHeader = "X-Algolia-API-Key";


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Need Doc update   | no

This fixes a typo in the code (`WriteTimeut` → `WriteTimeout`).