### PR TITLE
fix: missing catch clause in httpRequester

### DIFF
--- a/src/Algolia.Search/Http/AlgoliaHttpRequester.cs
+++ b/src/Algolia.Search/Http/AlgoliaHttpRequester.cs
@@ -124,9 +124,15 @@ namespace Algolia.Search.Http
                     }
                 }
             }
-            catch (TimeoutException timeOutException)
+            catch (TimeoutException e)
             {
-                return new AlgoliaHttpResponse { IsTimedOut = true, Error = timeOutException.ToString() };
+                return new AlgoliaHttpResponse { IsTimedOut = true, Error = e.ToString() };
+            }
+            catch (HttpRequestException e)
+            {
+                // HttpRequestException is thrown when an underlying issue happened such as
+                // network connectivity, DNS failure, server certificate validation.
+                return new AlgoliaHttpResponse { IsNetworkError = true, Error = e.ToString() };
             }
         }
     }

--- a/src/Algolia.Search/Http/AlgoliaHttpResponse.cs
+++ b/src/Algolia.Search/Http/AlgoliaHttpResponse.cs
@@ -46,6 +46,11 @@ namespace Algolia.Search.Http
         public bool IsTimedOut { get; set; }
 
         /// <summary>
+        /// Network connectivity, DNS failure, server certificate validation.
+        /// </summary>
+        public bool IsNetworkError { get; set; }
+
+        /// <summary>
         /// Http Error message
         /// </summary>
         public string Error { get; set; }

--- a/src/Algolia.Search/Transport/HttpTransport.cs
+++ b/src/Algolia.Search/Transport/HttpTransport.cs
@@ -121,7 +121,7 @@ namespace Algolia.Search.Transport
                     .SendRequestAsync(request, requestTimeout, ct)
                     .ConfigureAwait(false);
 
-                switch (_retryStrategy.Decide(host, response.HttpStatusCode, response.IsTimedOut))
+                switch (_retryStrategy.Decide(host, response))
                 {
                     case RetryOutcomeType.Success:
                         return SerializerHelper.Deserialize<TResult>(response.Body,


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Need Doc update   | no

## Describe your change

The `AlgoliaHttpRequester` was not catching correctly all exceptions, making the retry strategy to fail for a specific network exception instead of retrying. In fact, the `RetryStrategy` was not retrying for retryable failures such as DNS failure, server certificate validation. 
