### PR TITLE
Feat(indexLanguages)

### DIFF
--- a/src/Algolia.Search.Test/EndToEnd/Index/SettingsTest.cs
+++ b/src/Algolia.Search.Test/EndToEnd/Index/SettingsTest.cs
@@ -22,7 +22,6 @@
 */
 
 using Algolia.Search.Clients;
-using Algolia.Search.Models.Enums;
 using Algolia.Search.Models.Settings;
 using NUnit.Framework;
 using System.Collections.Generic;
@@ -105,6 +104,7 @@ namespace Algolia.Search.Test.EndToEnd.Index
                 DisableExactOnAttributes = new List<string> { "attribute1", "attribute2" },
                 ExactOnSingleWordQuery = "word",
                 QueryLanguages = new List<string> { "fr", "en" },
+                IndexLanguages = new List<string> { "ja" },
                 AdvancedSyntaxFeatures = new List<string> { "exactPhrase" },
                 AlternativesAsExact = new List<string> { "ignorePlurals" },
 

--- a/src/Algolia.Search/Models/Settings/IndexSettings.cs
+++ b/src/Algolia.Search/Models/Settings/IndexSettings.cs
@@ -196,6 +196,11 @@ namespace Algolia.Search.Models.Settings
         /// </summary>
         public List<string> QueryLanguages { get; set; }
 
+        /// <summary>
+        /// A list of language ISO code
+        /// </summary>
+        public List<string> IndexLanguages { get; set; }
+
         // query rules
 
         /// <summary>


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no     
| Related Issue     | Fix #636
| Need Doc update   | yes


## Describe your change

Implement the new `indexLanguages` setting which is an array of strings.
Currently, only `["ja"]` is supported by the engine.
