### PR TITLE
feat(queryRules/alternatives)

### DIFF
--- a/src/Algolia.Search.Test/EndToEnd/Index/QueryRulesTest.cs
+++ b/src/Algolia.Search.Test/EndToEnd/Index/QueryRulesTest.cs
@@ -90,7 +90,12 @@ namespace Algolia.Search.Test.EndToEnd.Index
             Rule ruleToSave2 = new Rule
             {
                 ObjectID = "query_edits",
-                Condition = new Condition { Anchoring = "is", Pattern = "mobile phone" },
+                Condition = new Condition
+                {
+                    Anchoring = "is",
+                    Pattern = "mobile phone",
+                    Alternatives = Alternatives.Of(true)
+                },
                 Consequence = new Consequence
                 {
                     Params = new ConsequenceParams

--- a/src/Algolia.Search/Models/Rules/Alternatives.cs
+++ b/src/Algolia.Search/Models/Rules/Alternatives.cs
@@ -1,0 +1,54 @@
+/*
+* Copyright (c) 2019 Algolia
+* http://www.algolia.com/
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+
+using Newtonsoft.Json;
+
+/// <summary>
+/// Alternatives make the rule to trigger on synonyms, typos and plurals.
+/// This class is an abstract factory because Alternatives will become in the future a complex JSON Object
+/// </summary>
+public abstract class Alternatives
+{
+    /// <summary>
+    /// Creates the boolean subtype of Alternatives
+    /// </summary>
+    /// <param name="value"></param>
+    public static Alternatives Of(bool value)
+    {
+        return new AlternativesBoolean(value);
+    }
+
+    /// <summary>
+    /// Alternatives can have multiple subtype such as <see cref="AlternativesBoolean"/>
+    /// </summary>
+    [JsonIgnore]
+    public object InsideValue { get; protected set; }
+}
+
+internal class AlternativesBoolean : Alternatives
+{
+    public AlternativesBoolean(bool value)
+    {
+        InsideValue = value;
+    }
+}

--- a/src/Algolia.Search/Serializer/AlternativesConverter.cs
+++ b/src/Algolia.Search/Serializer/AlternativesConverter.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 * Copyright (c) 2018 Algolia
 * http://www.algolia.com/
 *
@@ -21,37 +21,38 @@
 * THE SOFTWARE.
 */
 
-using Algolia.Search.Serializer;
 using Newtonsoft.Json;
+using System;
 
-namespace Algolia.Search.Models.Rules
+namespace Algolia.Search.Serializer
 {
     /// <summary>
-    /// Condition of a rule
+    /// Custom converter for Alternatives object
     /// </summary>
-    public class Condition
+    public class AlternativesConverter : JsonConverter<Alternatives>
     {
         /// <summary>
-        /// Query patterns are expressed as a string with a specific syntax. A pattern is a sequence of tokens.
+        /// Read the JSON taking into account the polymorphism of Alternatives
         /// </summary>
-        public string Pattern { get; set; }
+        public override Alternatives ReadJson(JsonReader reader, Type objectType, Alternatives existingValue,
+            bool hasExistingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.Null)
+                return null;
+
+            if (reader.TokenType == JsonToken.Boolean)
+                return Alternatives.Of(Convert.ToBoolean(reader.Value));
+
+            return null;
+        }
 
         /// <summary>
-        /// { is | startsWith | endsWith | contains }: Whether the pattern must match the beginning or the end of the query string, or both, or none.
+        /// Write the JSON taking into account the polymorphism of Alternatives
         /// </summary>
-        public string Anchoring { get; set; }
-
-        /// <summary>
-        /// Rule context (format: [A-Za-z0-9_-]+). When specified, the rule is contextual and applies only when the same context is specified at query time (using the ruleContexts parameter).
-        /// When absent, the rule is generic and always applies (provided that its other conditions are met, of course).
-        /// </summary>
-        public string Context { get; set; }
-
-        /// <summary>
-        /// If set to true, alternatives make the rule to trigger on synonyms, typos and plurals.
-        /// Note that setting ignorePlurals to false overrides this parameter.
-        /// </summary>
-        [JsonConverter(typeof(AlternativesConverter))]
-        public Alternatives Alternatives { get; set; }
+        public override void WriteJson(JsonWriter writer, Alternatives value, JsonSerializer serializer)
+        {
+            if (value.GetType() == typeof(AlternativesBoolean))
+                writer.WriteValue(value.InsideValue);
+        }
     }
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no     
| Related Issue     | Fix #637 
| Need Doc update   | yes

## Changes

This PR adds the`Alternatives` parameter in QueryRules conditions

Alternatives may transform into JSON object in the future.

That's why it comes with a customer serializer and
an abstract factory.
