### PR TITLE
Fix(JsonReader/LegacyFIlters)

### DIFF
--- a/src/Algolia.Search/Models/Search/Query.cs
+++ b/src/Algolia.Search/Models/Search/Query.cs
@@ -60,16 +60,19 @@ namespace Algolia.Search.Models.Search
         /// <summary>
         /// Filter hits by facet value.
         /// </summary>
+        [JsonConverter(typeof(FiltersConverter))]
         public IEnumerable<IEnumerable<string>> FacetFilters { get; set; }
 
         /// <summary>
         /// Create filters for ranking purposes, where records that match the filter are ranked highest.
         /// </summary>
+        [JsonConverter(typeof(FiltersConverter))]
         public IEnumerable<IEnumerable<string>> OptionalFilters { get; set; }
 
         /// <summary>
         /// Filter on numeric attributes.
         /// </summary>
+        [JsonConverter(typeof(FiltersConverter))]
         public IEnumerable<IEnumerable<string>> NumericFilters { get; set; }
 
         /// <summary>
@@ -77,6 +80,7 @@ namespace Algolia.Search.Models.Search
         /// tagFilters is a different way of filtering, which relies on the _tags attribute. It uses a simpler syntax than filters.
         /// You can use it when you want to do simple filtering based on tags.
         /// </summary>
+        [JsonConverter(typeof(FiltersConverter))]
         public IEnumerable<IEnumerable<string>> TagFilters { get; set; }
 
         /// <summary>

--- a/src/Algolia.Search/Serializer/FiltersConverter.cs
+++ b/src/Algolia.Search/Serializer/FiltersConverter.cs
@@ -1,0 +1,97 @@
+/*
+* Copyright (c) 2018 Algolia
+* http://www.algolia.com/
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Algolia.Search.Serializer
+{
+    /// <summary>
+    /// Custom converter for legacy Filters
+    /// </summary>
+    public class FiltersConverter : JsonConverter<IEnumerable<IEnumerable<string>>>
+    {
+        /// <summary>
+        /// No need to implement this method as we don't want to override default writer
+        /// </summary>
+        public override void WriteJson(JsonWriter writer, IEnumerable<IEnumerable<string>> value,
+            JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Algolia's specific reader to handle multiple form of legacy filters
+        /// This reader is converting single string to nested arrays
+        /// This reader is also converting single array to nested arrays
+        /// </summary>
+        public override IEnumerable<IEnumerable<string>> ReadJson(JsonReader reader, Type objectType,
+            IEnumerable<IEnumerable<string>> existingValue,
+            bool hasExistingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.Null)
+                return null;
+
+            if (reader.TokenType == JsonToken.StartArray)
+            {
+                JToken token = JToken.Load(reader);
+                var ret = new List<List<string>>();
+                var tmpList = new List<string>();
+
+                foreach (var tokenValue in token)
+                {
+                    switch (tokenValue.Type)
+                    {
+                        case JTokenType.Null:
+                            break;
+                        case JTokenType.String:
+                            tmpList.Add(tokenValue.ToObject<string>());
+                            break;
+                        case JTokenType.Array:
+                            var jArray = (JArray)tokenValue;
+                            ret.Add(jArray.ToObject<List<string>>());
+                            break;
+                    }
+                }
+
+                if (tmpList.Count > 0)
+                    ret.Add(tmpList);
+
+                return ret;
+            }
+
+            if (reader.TokenType == JsonToken.String)
+                return new List<List<string>> { Convert.ToString(reader.Value).Split(',').ToList() };
+
+            throw new JsonSerializationException($"Error while reading Token {reader.Value} of type {reader.TokenType}.");
+        }
+
+        /// <summary>
+        /// Disable write json
+        /// </summary>
+        public override bool CanWrite => false;
+    }
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| BC breaks?        | no     
| Need Doc update   | no

## What problem is this fixing?

Legacy form of `filters` were not supported by the JsonReader.

one string legacy filters `"color:green,color:yellow"` are converted
to "ORED" nested filters `[["color:green","color:yellow"]]`

array legacy filters [`"color:green","color:yellow"]` are converted
to "ORED" nested filters `[["color:green","color:yellow"]]`

