### PR TITLE
fix: saveObject throwing "data should not be IEnumerable" with JObject

### DIFF
--- a/src/Algolia.Search.Test/EndToEnd/Index/IndexingTest.cs
+++ b/src/Algolia.Search.Test/EndToEnd/Index/IndexingTest.cs
@@ -30,6 +30,7 @@ using NUnit.Framework;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
 
 namespace Algolia.Search.Test.EndToEnd.Index
 {
@@ -267,12 +268,12 @@ namespace Algolia.Search.Test.EndToEnd.Index
         [Parallelizable]
         public async Task MoveIndexTest()
         {
-            var objectOne = new AlgoliaStub { ObjectId = "one" };
+            var objectOne = new JObject { { "objectID", "one" } };
             var addObject = await _indexMove.SaveObjectAsync(objectOne);
 
             addObject.Wait();
 
-            string indexDestName = TestHelper.GetTestIndexName("move_test_dest");
+            var indexDestName = TestHelper.GetTestIndexName("move_test_dest");
 
             var move = await BaseTest.SearchClient.MoveIndexAsync(_indexMoveName, indexDestName);
             move.Wait();

--- a/src/Algolia.Search/Clients/SearchIndex.cs
+++ b/src/Algolia.Search/Clients/SearchIndex.cs
@@ -33,6 +33,7 @@ using Algolia.Search.Models.Settings;
 using Algolia.Search.Models.Synonyms;
 using Algolia.Search.Transport;
 using Algolia.Search.Utils;
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -150,7 +151,7 @@ namespace Algolia.Search.Clients
                 throw new ArgumentNullException(nameof(data));
             }
 
-            if (data is IEnumerable)
+            if (data is IEnumerable && !(data is JObject))
             {
                 throw new ArgumentException($"{nameof(data)} should not be an IEnumerable/List/Collection");
             }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | yes/no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | Fix #654
| Need Doc update   | no


## Describe your change

This commit adds additional check in the `SaveObject()` method, to allow JObject as parameter.
