### PR TITLE
fix: Type in synonym query is now a String instead String[]

### DIFF
--- a/src/Algolia.Search/Models/Synonyms/SynonymQuery.cs
+++ b/src/Algolia.Search/Models/Synonyms/SynonymQuery.cs
@@ -47,7 +47,7 @@ namespace Algolia.Search.Models.Synonyms
         /// <summary>
         /// There are 4 synonym types. The parameter can be one of the following values <see cref="Enums.SynonymType"/>
         /// </summary>
-        public List<string> Type { get; set; }
+        public string Type { get; set; }
 
         /// <summary>
         /// Page to retrieve

--- a/src/Algolia.Search/Models/Synonyms/SynonymQuery.cs
+++ b/src/Algolia.Search/Models/Synonyms/SynonymQuery.cs
@@ -21,8 +21,6 @@
 * THE SOFTWARE.
 */
 
-using System.Collections.Generic;
-
 namespace Algolia.Search.Models.Synonyms
 {
     /// <summary>
@@ -42,7 +40,7 @@ namespace Algolia.Search.Models.Synonyms
         /// <summary>
         /// The text to search
         /// </summary>
-        public string Query { get; set; } = string.Empty;
+        public string Query { get; set; }
 
         /// <summary>
         /// There are 4 synonym types. The parameter can be one of the following values <see cref="Enums.SynonymType"/>


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| Need Doc update   | yes

## Describe your change

Fixed the type of "SynonymQuery.Type". It's now a String instead
of a List<string>.

For example: Type =  "synonym,oneWaySynonym,placeholder"
