### PR TITLE
feat:Bump library to .NET Standard 2.1 / .Net Core 3

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,6 +7,11 @@ jobs:
     pool:
       vmImage: vs2017-win2016
     steps:
+      - task: UseDotNet@2
+        displayName: Install .NET Core 3.0 SDK
+        inputs:
+            packageType: 'sdk'
+            version: '3.0.100'
       - script: dotnet build src -c $(buildConfiguration)
         displayName: Run build
       - script: >-
@@ -38,11 +43,21 @@ jobs:
     pool:
       vmImage: macOS-10.13
     steps:
+      - task: UseDotNet@2
+        displayName: Install .NET Core 3.0 SDK
+        inputs:
+          packageType: 'sdk'
+          version: '3.0.100'
       - script: dotnet build src -c $(buildConfiguration)
   - job: Linux
     pool:
       vmImage: ubuntu-16.04
     steps:
+      - task: UseDotNet@2
+        displayName: Install .NET Core 3.0 SDK
+        inputs:
+            packageType: 'sdk'
+            version: '3.0.100'
       - script: dotnet build src -c $(buildConfiguration)
         displayName: Run build
       - script: >-

--- a/src/Algolia.Search.Test/Algolia.Search.Test.csproj
+++ b/src/Algolia.Search.Test/Algolia.Search.Test.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp2.2</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netcoreapp2.1;net45;</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netcoreapp3.0;netcoreapp2.1;net45;</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Algolia.Search/Algolia.Search.csproj
+++ b/src/Algolia.Search/Algolia.Search.csproj
@@ -14,22 +14,22 @@
     <RepositoryUrl>https://github.com/algolia/algoliasearch-client-csharp</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageDescription>
-    Algolia is a powerful search-as-a-service solution, made easy to use with API clients, UI libraries, and pre-built integrations. Algolia API Client for the .NET framework lets you easily use the Algolia Search REST API from your .NET code.
+      Algolia is a powerful search-as-a-service solution, made easy to use with API clients, UI libraries, and pre-built integrations. Algolia API Client for the .NET framework lets you easily use the Algolia Search REST API from your .NET code.
     </PackageDescription>
     <RequireLicenseAcceptance>false</RequireLicenseAcceptance>
     <Copyright>Copyright 2019 Algolia</Copyright>
     <Version>6.4.0</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard2.0;netstandard1.3</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netstandard2.0;netstandard1.3;net45;</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard2.1;netstandard2.0;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netstandard2.1;netstandard2.0;netstandard1.3;net45;</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3' OR '$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3' OR '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2"/>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
-    <Reference Include="System" />
-    <Reference Include="System.Net.Http" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2"/>
+    <Reference Include="System"/>
+    <Reference Include="System.Net.Http"/>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | Fix #651 
| Need Doc update   | no


## Describe your change

This PR is adding support for `.NET Standard 2.1` and `.NET Core 3`.
Another PR will take care of adding the new std JSON Serializer