### PR TITLE
internal: ISerializer interface

### DIFF
--- a/src/Algolia.Search/Http/AlgoliaHttpRequester.cs
+++ b/src/Algolia.Search/Http/AlgoliaHttpRequester.cs
@@ -114,11 +114,9 @@ namespace Algolia.Search.Http
                             };
                         }
 
-                        var content = await SerializerHelper.StreamToStringAsync(stream).ConfigureAwait(false);
-
                         return new AlgoliaHttpResponse
                         {
-                            Error = content,
+                            Error = await StreamToStringAsync(stream),
                             HttpStatusCode = (int)response.StatusCode
                         };
                     }
@@ -134,6 +132,21 @@ namespace Algolia.Search.Http
                 // network connectivity, DNS failure, server certificate validation.
                 return new AlgoliaHttpResponse { IsNetworkError = true, Error = e.ToString() };
             }
+        }
+
+        private async Task<string> StreamToStringAsync(Stream stream)
+        {
+            string content;
+
+            if (stream == null)
+                return null;
+
+            using (var sr = new StreamReader(stream))
+            {
+                content = await sr.ReadToEndAsync().ConfigureAwait(false);
+            }
+
+            return content;
         }
     }
 }

--- a/src/Algolia.Search/Models/Enums/CompressionType.cs
+++ b/src/Algolia.Search/Models/Enums/CompressionType.cs
@@ -31,11 +31,11 @@ namespace Algolia.Search.Models.Enums
         /// <summary>
         /// No compression
         /// </summary>
-        NONE,
+        NONE = 1,
 
         /// <summary>
         /// GZip Compression. Only supported by Search API.
         /// </summary>
-        GZIP
+        GZIP = 2
     }
 }

--- a/src/Algolia.Search/Serializer/DefaultSerializer.cs
+++ b/src/Algolia.Search/Serializer/DefaultSerializer.cs
@@ -25,6 +25,7 @@ using Newtonsoft.Json;
 using System.IO;
 using System.IO.Compression;
 using System.Text;
+using Algolia.Search.Models.Enums;
 
 namespace Algolia.Search.Serializer
 {
@@ -40,9 +41,9 @@ namespace Algolia.Search.Serializer
         // Buffer sized as recommended by Bradley Grainger, http://faithlife.codes/blog/2012/06/always-wrap-gzipstream-with-bufferedstream/
         private static readonly int GZipBufferSize = 8192;
 
-        public void Serialize<T>(T data, Stream stream, bool gzipCompress)
+        public void Serialize<T>(T data, Stream stream, CompressionType compressionType)
         {
-            if (gzipCompress)
+            if (compressionType == CompressionType.GZIP)
             {
                 using (var gzipStream = new GZipStream(stream, CompressionMode.Compress, true))
                 using (var sw = new StreamWriter(gzipStream, DefaultEncoding, GZipBufferSize))

--- a/src/Algolia.Search/Serializer/ISerializer.cs
+++ b/src/Algolia.Search/Serializer/ISerializer.cs
@@ -22,6 +22,7 @@
 */
 
 using System.IO;
+using Algolia.Search.Models.Enums;
 
 namespace Algolia.Search.Serializer
 {
@@ -35,9 +36,9 @@ namespace Algolia.Search.Serializer
         /// </summary>
         /// <param name="data">The value to convert and write.</param>
         /// <param name="stream">The Stream containing the data to read.</param>
-        /// <param name="gzipCompress">Whether the underlying stream should be compressed or not</param>
+        /// <param name="compressionType">How the stream should be compressed <see cref="CompressionType"/></param>
         /// <typeparam name="T">The type of the value to convert.</typeparam>
-        void Serialize<T>(T data, Stream stream, bool gzipCompress);
+        void Serialize<T>(T data, Stream stream, CompressionType compressionType);
 
         /// <summary>
         /// Parses the stream into an instance of a specified type.

--- a/src/Algolia.Search/Serializer/ISerializer.cs
+++ b/src/Algolia.Search/Serializer/ISerializer.cs
@@ -1,0 +1,50 @@
+/*
+* Copyright (c) 2018 Algolia
+* http://www.algolia.com/
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+
+using System.IO;
+
+namespace Algolia.Search.Serializer
+{
+    /// <summary>
+    /// Interface representing the expected behavior of the Serializer.
+    /// </summary>
+    internal interface ISerializer
+    {
+        /// <summary>
+        /// Converts the value of a specified type into a JSON string.
+        /// </summary>
+        /// <param name="data">The value to convert and write.</param>
+        /// <param name="stream">The Stream containing the data to read.</param>
+        /// <param name="gzipCompress">Whether the underlying stream should be compressed or not</param>
+        /// <typeparam name="T">The type of the value to convert.</typeparam>
+        void Serialize<T>(T data, Stream stream, bool gzipCompress);
+
+        /// <summary>
+        /// Parses the stream into an instance of a specified type.
+        /// </summary>
+        /// <param name="stream">The Stream containing the data to read.</param>
+        /// <typeparam name="T">The type of the value to convert.</typeparam>
+        /// <returns></returns>
+        T Deserialize<T>(Stream stream);
+    }
+}

--- a/src/Algolia.Search/Transport/HttpTransport.cs
+++ b/src/Algolia.Search/Transport/HttpTransport.cs
@@ -151,7 +151,8 @@ namespace Algolia.Search.Transport
 
             MemoryStream ms = new MemoryStream();
 
-            _serializer.Serialize(data, ms, compress);
+            CompressionType compressionType = compress ? CompressionType.GZIP : CompressionType.NONE;
+            _serializer.Serialize(data, ms, compressionType);
 
             ms.Seek(0, SeekOrigin.Begin);
             return ms;

--- a/src/Algolia.Search/Transport/HttpTransport.cs
+++ b/src/Algolia.Search/Transport/HttpTransport.cs
@@ -45,6 +45,7 @@ namespace Algolia.Search.Transport
     internal class HttpTransport
     {
         private readonly IHttpRequester _httpClient;
+        private readonly ISerializer _serializer;
         private readonly RetryStrategy _retryStrategy;
         private readonly AlgoliaConfig _algoliaConfig;
 
@@ -57,6 +58,7 @@ namespace Algolia.Search.Transport
         {
             _algoliaConfig = config ?? throw new ArgumentNullException(nameof(config));
             _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+            _serializer = new DefaultSerializer();
             _retryStrategy = new RetryStrategy(config);
         }
 
@@ -124,8 +126,7 @@ namespace Algolia.Search.Transport
                 switch (_retryStrategy.Decide(host, response))
                 {
                     case RetryOutcomeType.Success:
-                        return SerializerHelper.Deserialize<TResult>(response.Body,
-                            JsonConfig.AlgoliaJsonSerializerSettings);
+                        return _serializer.Deserialize<TResult>(response.Body);
                     case RetryOutcomeType.Retry:
                         continue;
                     case RetryOutcomeType.Failure:
@@ -145,17 +146,16 @@ namespace Algolia.Search.Transport
         /// <returns></returns>
         private MemoryStream CreateRequestContent<T>(T data, bool compress)
         {
-            if (data != null)
-            {
-                MemoryStream ms = new MemoryStream();
+            if (data == null)
+                return null;
 
-                SerializerHelper.Serialize(data, ms, JsonConfig.AlgoliaJsonSerializerSettings, compress);
+            MemoryStream ms = new MemoryStream();
 
-                ms.Seek(0, SeekOrigin.Begin);
-                return ms;
-            }
+            _serializer.Serialize(data, ms, compress);
 
-            return null;
+            ms.Seek(0, SeekOrigin.Begin);
+            return ms;
+
         }
 
         /// <summary>


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no     
| Need Doc update   | not yet

## Describe your change

This commit is adding the `ISerializer` interface to anticipate different
implementations of the latter.

With the upcoming support of .NET Core 3 the library will support
both `Newtonsoft.JSON` and `System.Text.Json`

`ISerializer` will allow us to switch between both implementations
more easily with the help of pre-processor:

```csharp
#IF NETCOREAPP3_0
 System.Text.Json
#ELSE
 Newtonsoft.JSON
#ENDIF
```
