### PR TITLE
feat(query): explain decompounding at query time

### DIFF
--- a/src/Algolia.Search/Models/Search/Alternative.cs
+++ b/src/Algolia.Search/Models/Search/Alternative.cs
@@ -1,0 +1,58 @@
+/*
+* Copyright (c) 2018 Algolia
+* http://www.algolia.com/
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+
+using System.Collections.Generic;
+
+namespace Algolia.Search.Models.Search
+{
+    /// <summary>
+    ///  Query match alternatives
+    /// </summary>
+    public class Alternative
+    {
+        /// <summary>
+        /// Alternative type
+        /// </summary>
+        public string Type { get; set; }
+
+        /// <summary>
+        /// Alternative words
+        /// </summary>
+        public IEnumerable<string> Words { get; set; }
+
+        /// <summary>
+        /// Number of typos
+        /// </summary>
+        public long Typos { get; set; }
+
+        /// <summary>
+        /// Offset
+        /// </summary>
+        public long Offset { get; set; }
+
+        /// <summary>
+        /// Length
+        /// </summary>
+        public long Length { get; set; }
+    }
+}

--- a/src/Algolia.Search/Models/Search/Explain.cs
+++ b/src/Algolia.Search/Models/Search/Explain.cs
@@ -1,0 +1,45 @@
+/*
+* Copyright (c) 2018 Algolia
+* http://www.algolia.com/
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Algolia.Search.Models.Search
+{
+    /// <summary>
+    /// Explain decompounding at query time
+    /// </summary>
+    public class Explain
+    {
+        /// <summary>
+        /// Query match
+        /// </summary>
+        [JsonProperty(PropertyName = "match")]
+        public QueryMatch QueryMatch { get; set; }
+
+        /// <summary>
+        /// Query parameter reporting. Parameters are reported as a JSON object with one field per parameter.
+        /// </summary>
+        public Dictionary<string,object> Params { get; set; }
+    }
+}

--- a/src/Algolia.Search/Models/Search/Explain.cs
+++ b/src/Algolia.Search/Models/Search/Explain.cs
@@ -22,7 +22,6 @@
 */
 
 using System.Collections.Generic;
-using Newtonsoft.Json;
 
 namespace Algolia.Search.Models.Search
 {
@@ -34,8 +33,7 @@ namespace Algolia.Search.Models.Search
         /// <summary>
         /// Query match
         /// </summary>
-        [JsonProperty(PropertyName = "match")]
-        public QueryMatch QueryMatch { get; set; }
+        public QueryMatch Match { get; set; }
 
         /// <summary>
         /// Query parameter reporting. Parameters are reported as a JSON object with one field per parameter.

--- a/src/Algolia.Search/Models/Search/Query.cs
+++ b/src/Algolia.Search/Models/Search/Query.cs
@@ -380,6 +380,11 @@ namespace Algolia.Search.Models.Search
         public bool? GetRankingInfo { get; set; }
 
         /// <summary>
+        /// Explain decompounding at query time
+        /// </summary>
+        public List<string> Explain { get; set; }
+
+        /// <summary>
         /// A user identifier.
         /// Format: alpha numeric string [a-zA-Z0-9_-]
         /// Length: between 1 and 64 characters.

--- a/src/Algolia.Search/Models/Search/QueryMatch.cs
+++ b/src/Algolia.Search/Models/Search/QueryMatch.cs
@@ -1,0 +1,38 @@
+/*
+* Copyright (c) 2018 Algolia
+* http://www.algolia.com/
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+
+using System.Collections.Generic;
+
+namespace Algolia.Search.Models.Search
+{
+    /// <summary>
+    /// Query match
+    /// </summary>
+    public class QueryMatch
+    {
+        /// <summary>
+        /// Returned Alternatives
+        /// </summary>
+        public IEnumerable<Alternative> Alternatives { get; set; }
+    }
+}

--- a/src/Algolia.Search/Models/Search/SearchResponse.cs
+++ b/src/Algolia.Search/Models/Search/SearchResponse.cs
@@ -160,6 +160,11 @@ namespace Algolia.Search.Models.Search
         public string ParsedQuery { get; set; }
 
         /// <summary>
+        /// Explain decompounding at query time
+        /// </summary>
+        public Explain Explain { get; set; }
+
+        /// <summary>
         /// Custom user data
         /// </summary>
         public object UserData { get; set; }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no     
| Related Issue     | Fix #674 
| Need Doc update   | yes

## Describe your change

- adds `Explain` parameter in `Query`
- adds `Explain` response property in `SearchResponse`

Waiting for CTS test and better documentation before merging.