### PR TITLE
patch: serialization/deserialization of ConsequenceQuery

### DIFF
--- a/src/Algolia.Search/Models/Rules/ConsequenceParams.cs
+++ b/src/Algolia.Search/Models/Rules/ConsequenceParams.cs
@@ -34,11 +34,31 @@ namespace Algolia.Search.Models.Rules
     public class ConsequenceParams : Query
     {
         /// <summary>
-        /// When providing a string, it replaces the entire query string.
-        /// When providing an object, it describes incremental edits to be made to the query string (but you can’t do both).
+        /// When providing an object, it describes incremental edits to be made to the query string.
         /// </summary>
-        [JsonConverter(typeof(ConsequenceQueryConverter))]
+        /// <remarks>Setting a ConsequenceQuery will override SearchQuery if set. Both can't be set at the same time.</remarks>
         public ConsequenceQuery Query { get; set; }
+
+        /// <summary>
+        /// Providing a SearchQuery in ConsequenceParams replaces the entire query string for the given pattern.
+        /// </summary>
+        /// <remarks>Setting a SearchQuery will override ConsequenceQuery if set. Both can't be set at the same time.</remarks>
+        [JsonIgnore]
+        public new string SearchQuery
+        {
+            get
+            {
+                return Query?.SearchQuery;
+            }
+
+            set
+            {
+                if (Query == null)
+                {
+                    Query = new ConsequenceQuery { SearchQuery = value };
+                }
+            }
+        }
 
         /// <summary>
         /// Names of facets to which automatic filtering must be applied; they must match the facet name of a facet value placeholder in the query pattern.

--- a/src/Algolia.Search/Models/Rules/ConsequenceParams.cs
+++ b/src/Algolia.Search/Models/Rules/ConsequenceParams.cs
@@ -53,10 +53,7 @@ namespace Algolia.Search.Models.Rules
 
             set
             {
-                if (Query == null)
-                {
-                    Query = new ConsequenceQuery { SearchQuery = value };
-                }
+                Query = new ConsequenceQuery { SearchQuery = value };
             }
         }
 

--- a/src/Algolia.Search/Models/Rules/ConsequenceQuery.cs
+++ b/src/Algolia.Search/Models/Rules/ConsequenceQuery.cs
@@ -21,6 +21,8 @@
 * THE SOFTWARE.
 */
 
+using Algolia.Search.Serializer;
+using Newtonsoft.Json;
 using System.Collections.Generic;
 
 namespace Algolia.Search.Models.Rules
@@ -28,8 +30,15 @@ namespace Algolia.Search.Models.Rules
     /// <summary>
     /// Consequence query
     /// </summary>
+    [JsonConverter(typeof(ConsequenceQueryConverter))]
     public class ConsequenceQuery
     {
+        /// <summary>
+        /// Stores a SearchQuery if defined.
+        /// Value could be used during deserialization/serialization
+        /// </summary>
+        internal string SearchQuery { get; set; }
+
         /// <summary>
         /// List of edits
         /// </summary>


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Need Doc update   | yes/no

## Describe your change

[changelog]

Fixed: Custom serializer to handle polymorphism of "query" attribute
in ConsequenceQuery

Example:

```json
// query string
"query": "some query string"

// remove attribute (deprecated)
"query": {"remove": ["query1", "query2"]}

// edits attribute
"query": {
   "edits": [
   { "type": "remove", "delete": "old" },
   { "type": "replace", "delete": "new", "insert": "newer" }
   ]
}}
```json
