### PR TITLE
fix(apiKey): bad separator for restrictSources/restrictIndices

### DIFF
--- a/src/Algolia.Search/Utils/QueryStringHelper.cs
+++ b/src/Algolia.Search/Utils/QueryStringHelper.cs
@@ -45,13 +45,13 @@ namespace Algolia.Search.Utils
             string restrictIndices = null;
             if (restriction.RestrictIndices != null)
             {
-                restrictIndices = $"restrictIndices={string.Join(";", restriction.RestrictIndices)}";
+                restrictIndices = $"restrictIndices={string.Join(",", restriction.RestrictIndices)}";
             }
 
             string restrictSources = null;
             if (restriction.RestrictSources != null)
             {
-                restrictSources = $"restrictSources={string.Join(";", restriction.RestrictSources)}";
+                restrictSources = $"restrictSources={string.Join(",", restriction.RestrictSources)}";
             }
 
             string restrictionQueryParams = ToQueryString(restriction, nameof(restriction.Query),


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | Fix #694 Fix #695 Fix #696 
| Need Doc update   | no


## Describe your change

Separators `;` is no longer allowed for `restrictSources` and `restrictIndices`

For the record, Java is fixed as well:

 https://github.com/algolia/algoliasearch-client-java-2/commit/4a8e356ca494c49505341e88be8aed950741df07
