### PR TITLE
chore(ci): update macOS image for Azure pipelines from 10.13 to 10.15

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,7 +41,7 @@ jobs:
           artifactName: package
   - job: macOS
     pool:
-      vmImage: macOS-10.13
+      vmImage: macOS-10.15
     steps:
       - task: UseDotNet@2
         displayName: Install .NET Core 3.0 SDK


### PR DESCRIPTION
Azure pipelines recently declared they were about to drop macOS 10.13
from their image pool. This commit hence update the macOS build for our
tests from macOS 10.13 to macOS 10.15, which is the most recent available
version at the moment.