### PR TITLE
feat(logs): adds inner_queries

### DIFF
--- a/src/Algolia.Search/Models/Common/LogResponse.cs
+++ b/src/Algolia.Search/Models/Common/LogResponse.cs
@@ -38,6 +38,36 @@ namespace Algolia.Search.Models.Common
     }
 
     /// <summary>
+    /// https://www.algolia.com/doc/api-reference/api-methods/get-logs/#method-response-inner_queries
+    /// Contains an object for each performed query with the indexName, queryID, offset, and userToken.
+    /// </summary>
+    public class InnerQueryLog
+    {
+        /// <summary>
+        /// The index used for the given query
+        /// </summary>
+        [JsonProperty(PropertyName = "index_name")]
+        public string IndexName { get; set; }
+
+        /// <summary>
+        /// The QueryID for the given query
+        /// </summary>
+        [JsonProperty(PropertyName = "query_id")]
+        public string QueryId { get; set; }
+
+        /// <summary>
+        /// User identifier
+        /// </summary>
+        [JsonProperty(PropertyName = "user_token")]
+        public string UserToken { get; set; }
+
+        /// <summary>
+        /// Specify the offset of the first hit to return
+        /// </summary>
+        public long? Offset { get; set; }
+    }
+
+    /// <summary>
     /// https://www.algolia.com/doc/api-reference/api-methods/get-logs/
     /// </summary>
     public class Log
@@ -115,5 +145,11 @@ namespace Algolia.Search.Models.Common
         /// Index name of the log
         /// </summary>
         public string Index { get; set; }
+
+        /// <summary>
+        /// Containers for each performed query for the given call.
+        /// </summary>
+        [JsonProperty(PropertyName = "inner_queries")]
+        public IEnumerable<InnerQueryLog> InnerQueries { get; set; }
     }
 }


### PR DESCRIPTION

| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes/no
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | Fix #700 
| Need Doc update   | yes


## Describe your change

Add the new `inner_queries` response field in GetLogs

```json
    "inner_queries": [
        {
            "index_name": "indexName",
            "query_id": "313453231",
            "offset": 0,
            "user_token": "user1"
        }
    ]
```