### PR TITLE
chore(ci): fix an error display message in release step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
       - run:
           name: "Release the new version"
           command: |
-            if [[ -z "$NUGET_API_KEY" ]]; then echo "$NUGET_API_KEY is not set"; exit 1; fi
+            if [[ -z "$NUGET_API_KEY" ]]; then echo '$NUGET_API_KEY is not set'; exit 1; fi
             dotnet nuget push $(ls src/Algolia.Search/bin/release/*.nupkg) -k $NUGET_API_KEY -s https://api.nuget.org/v3/index.json
 
 workflows:


### PR DESCRIPTION
This commit ensure that the message shows the name of the missing
environment variable *without* expanding it in the shell during the CI
release step.