### PR TITLE
fix: PartialUpdateObject() throwing "data should not be IEnumerable" with JObject

### DIFF
--- a/src/Algolia.Search.Test/EndToEnd/Index/IndexingTest.cs
+++ b/src/Algolia.Search.Test/EndToEnd/Index/IndexingTest.cs
@@ -300,11 +300,14 @@ namespace Algolia.Search.Test.EndToEnd.Index
 
             addObject.Wait();
 
-            //Add JObject without ID
+            //Add JObject without ID with autoGenerateObjectId
             var objectOneWoId = new JObject { { "title", "Bar" } };
             var addObjectWoId = await _indexWithJObject.SaveObjectAsync(objectOneWoId, autoGenerateObjectId: true);
 
             addObjectWoId.Wait();
+
+            //Add JObject without ID without autoGenerateObjectId
+            Assert.ThrowsAsync<AlgoliaApiException>(() => _indexWithJObject.SaveObjectAsync(objectOneWoId, autoGenerateObjectId: false));
 
             //Update record with JObject
             var objectTwo = new JObject { { "objectID", "one" }, { "title", "Baz" } };

--- a/src/Algolia.Search/Clients/SearchIndex.cs
+++ b/src/Algolia.Search/Clients/SearchIndex.cs
@@ -87,7 +87,7 @@ namespace Algolia.Search.Clients
                 throw new ArgumentNullException(nameof(data));
             }
 
-            if (data is IEnumerable)
+            if (data is IEnumerable && !(data is JObject))
             {
                 throw new ArgumentException($"{nameof(data)} should not be an IEnumerable/List/Collection");
             }

--- a/src/Algolia.Search/Utils/AlgoliaHelper.cs
+++ b/src/Algolia.Search/Utils/AlgoliaHelper.cs
@@ -105,11 +105,11 @@ namespace Algolia.Search.Utils
 
             if (itemType == typeof(JObject))
             {
-                string objectID = JObject.FromObject(data).Property("objectID").ToString();
+                JProperty objectID = JObject.FromObject(data).Property("objectID");
 
-                if (objectID != null || objectID != "")
+                if (objectID != null)
                 {
-                    return objectID;
+                    return objectID.ToString();
                 }
             }
 

--- a/src/Algolia.Search/Utils/AlgoliaHelper.cs
+++ b/src/Algolia.Search/Utils/AlgoliaHelper.cs
@@ -101,6 +101,18 @@ namespace Algolia.Search.Utils
         /// <returns></returns>
         internal static string GetObjectID<T>(T data)
         {
+            Type itemType = typeof(T);
+
+            if (itemType == typeof(JObject))
+            {
+                string objectID = JObject.FromObject(data).Property("objectID").ToString();
+
+                if (objectID != null || objectID != "")
+                {
+                    return objectID;
+                }
+            }
+
             var objectIdProperty = PropertyOrJsonAttributeExists<T>("ObjectID");
 
             if (objectIdProperty != null)

--- a/src/Algolia.Search/Utils/AlgoliaHelper.cs
+++ b/src/Algolia.Search/Utils/AlgoliaHelper.cs
@@ -107,7 +107,7 @@ namespace Algolia.Search.Utils
             {
                 JProperty objectID = JObject.FromObject(data).Property("objectID");
 
-                if (objectID != null)
+                if (objectID != null && objectID.ToString() != "")
                 {
                     return objectID.ToString();
                 }


### PR DESCRIPTION


| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | yes/no   
| BC breaks?        | no     
| Related Issue     | Fix #654
| Need Doc update   | no


## Describe your change

This commit adds additional check in the PartialUpdateObject() method, to allow JObject as parameter.