### PR TITLE
chore: fix CircleCI filtering to release only tagged commits

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,16 +55,25 @@ workflows:
   version: 2
   build:
     jobs:
-      - format
-      - build
-      - test
+      - format:
+          filters:
+            tags:
+              only: /.*/
+      - build:
+          filters:
+            tags:
+              only: /.*/
+      - test:
+          filters:
+            tags:
+              only: /.*/
       - release:
           requires:
             - format
             - build
             - test
           filters:
-            branches:
-              only: master
             tags:
               only: /^[1-9]+.[0-9]+.[0-9]+.*/
+            branches:
+              ignore: /.*/


### PR DESCRIPTION
See https://discuss.circleci.com/t/workflow-job-with-tag-filter-being-run-for-every-commit/20762/4
for more details (short answer: CircleCI filters are ORed instead of
ANDed since 2.0, also, all required jobs needs to accepts all tags).