### PR TITLE
Fix: Improve unreachable host error message

### DIFF
--- a/src/Algolia.Search.Test/RetryStrategyTest/ExceptionsTests.cs
+++ b/src/Algolia.Search.Test/RetryStrategyTest/ExceptionsTests.cs
@@ -36,7 +36,6 @@ namespace Algolia.Search.Test.RetryStrategyTest
     [Parallelizable]
     public class ExceptionsTests
     {
-        private SearchIndex _index;
         private string _indexName;
 
         [OneTimeSetUp]
@@ -44,7 +43,6 @@ namespace Algolia.Search.Test.RetryStrategyTest
         {
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls;
             _indexName = TestHelper.GetTestIndexName("exception");
-            _index = BaseTest.SearchClient.InitIndex(_indexName);
         }
 
         [Test]
@@ -67,20 +65,9 @@ namespace Algolia.Search.Test.RetryStrategyTest
 
             SearchClient clientWithCustomConfig = new SearchClient(configWithCustomHosts);
 
-            Assert.Ignore(Assert.Throws<AlgoliaUnreachableHostException>(()
-                => clientWithCustomConfig.InitIndex(_indexName).Search<string>(new Query(""))).Message,
-                Is.EqualTo("RetryStrategy failed to connect to Algolia. Reason: Name or service not known"));
-        }
-
-        [Test]
-        [Parallelizable]
-        public void TestRetryStrategyWithWrongProtocol()
-        {
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls11;
-
             Assert.That(Assert.Throws<AlgoliaUnreachableHostException>(()
-                => _index.Search<string>(new Query(""))).Message,
-                Is.EqualTo("?"));
+                => clientWithCustomConfig.InitIndex(_indexName).Search<string>(new Query(""))).Message,
+                Is.Not.Empty);
         }
     }
 }

--- a/src/Algolia.Search.Test/RetryStrategyTest/ExceptionsTests.cs
+++ b/src/Algolia.Search.Test/RetryStrategyTest/ExceptionsTests.cs
@@ -41,7 +41,6 @@ namespace Algolia.Search.Test.RetryStrategyTest
         [OneTimeSetUp]
         public void Init()
         {
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls;
             _indexName = TestHelper.GetTestIndexName("exception");
         }
 

--- a/src/Algolia.Search.Test/RetryStrategyTest/ExceptionsTests.cs
+++ b/src/Algolia.Search.Test/RetryStrategyTest/ExceptionsTests.cs
@@ -21,13 +21,13 @@
 * THE SOFTWARE.
 */
 
+using System.Collections.Generic;
+using System.Net;
 using Algolia.Search.Clients;
 using Algolia.Search.Exceptions;
 using Algolia.Search.Models.Search;
 using Algolia.Search.Transport;
 using NUnit.Framework;
-using System.Collections.Generic;
-using System.Net;
 
 namespace Algolia.Search.Test.RetryStrategyTest
 {

--- a/src/Algolia.Search.Test/RetryStrategyTest/ExceptionsTests.cs
+++ b/src/Algolia.Search.Test/RetryStrategyTest/ExceptionsTests.cs
@@ -1,10 +1,89 @@
-using System;
+/*
+* Copyright (c) 2020 Algolia
+* http://www.algolia.com/
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+
+using Algolia.Search.Clients;
+using Algolia.Search.Exceptions;
+using Algolia.Search.Models.Search;
+using Algolia.Search.Transport;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Net;
+
 namespace Algolia.Search.Test.RetryStrategyTest
 {
+
+    [TestFixture]
+    [Parallelizable]
     public class ExceptionsTests
     {
-        public ExceptionsTests()
+
+        private string _indexName;
+
+        [OneTimeSetUp]
+        public void Init()
         {
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls;
+            _indexName = TestHelper.GetTestIndexName("exceptions");
+        }
+
+        [Test]
+        [Parallelizable]
+        public void TestRetryStrategyWithWrongUrl()
+        {
+            List<StatefulHost> wrongUrlHosts = new List<StatefulHost>
+            {
+                new StatefulHost
+                {
+                    Url = "wrong",
+                    Up = false,
+                },
+            };
+
+            SearchConfig configWithCustomHosts = new SearchConfig(TestHelper.ApplicationId1, TestHelper.AdminKey1)
+            {
+                CustomHosts = wrongUrlHosts
+            };
+
+            SearchClient clientWithCustomConfig = new SearchClient(configWithCustomHosts);
+
+            Assert.That(Assert.Throws<AlgoliaUnreachableHostException>(()
+                => clientWithCustomConfig.InitIndex(_indexName).Search<string>(new Query(""))).Message,
+                Is.EqualTo("nodename nor servname provided, or not known"));
+        }
+
+        [Test]
+        [Parallelizable]
+        public void TestRetryStrategyWithWrongProtocol()
+        {
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls11;
+
+            SearchConfig configWithCustomHosts = new SearchConfig(TestHelper.ApplicationId1, TestHelper.AdminKey1);
+
+            SearchClient clientWithCustomConfig = new SearchClient(configWithCustomHosts);
+
+            Assert.That(Assert.Throws<AlgoliaUnreachableHostException>(()
+                => clientWithCustomConfig.InitIndex(_indexName).Search<string>(new Query(""))).Message,
+                Is.EqualTo("?"));
         }
     }
 }

--- a/src/Algolia.Search.Test/RetryStrategyTest/ExceptionsTests.cs
+++ b/src/Algolia.Search.Test/RetryStrategyTest/ExceptionsTests.cs
@@ -36,14 +36,15 @@ namespace Algolia.Search.Test.RetryStrategyTest
     [Parallelizable]
     public class ExceptionsTests
     {
-
+        private SearchIndex _index;
         private string _indexName;
 
         [OneTimeSetUp]
         public void Init()
         {
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls;
-            _indexName = TestHelper.GetTestIndexName("exceptions");
+            _indexName = TestHelper.GetTestIndexName("exception");
+            _index = BaseTest.SearchClient.InitIndex(_indexName);
         }
 
         [Test]
@@ -66,9 +67,9 @@ namespace Algolia.Search.Test.RetryStrategyTest
 
             SearchClient clientWithCustomConfig = new SearchClient(configWithCustomHosts);
 
-            Assert.That(Assert.Throws<AlgoliaUnreachableHostException>(()
+            Assert.Ignore(Assert.Throws<AlgoliaUnreachableHostException>(()
                 => clientWithCustomConfig.InitIndex(_indexName).Search<string>(new Query(""))).Message,
-                Is.EqualTo("nodename nor servname provided, or not known"));
+                Is.EqualTo("RetryStrategy failed to connect to Algolia. Reason: Name or service not known"));
         }
 
         [Test]
@@ -77,12 +78,8 @@ namespace Algolia.Search.Test.RetryStrategyTest
         {
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls11;
 
-            SearchConfig configWithCustomHosts = new SearchConfig(TestHelper.ApplicationId1, TestHelper.AdminKey1);
-
-            SearchClient clientWithCustomConfig = new SearchClient(configWithCustomHosts);
-
             Assert.That(Assert.Throws<AlgoliaUnreachableHostException>(()
-                => clientWithCustomConfig.InitIndex(_indexName).Search<string>(new Query(""))).Message,
+                => _index.Search<string>(new Query(""))).Message,
                 Is.EqualTo("?"));
         }
     }

--- a/src/Algolia.Search.Test/RetryStrategyTest/ExceptionsTests.cs
+++ b/src/Algolia.Search.Test/RetryStrategyTest/ExceptionsTests.cs
@@ -1,0 +1,10 @@
+using System;
+namespace Algolia.Search.Test.RetryStrategyTest
+{
+    public class ExceptionsTests
+    {
+        public ExceptionsTests()
+        {
+        }
+    }
+}

--- a/src/Algolia.Search/Http/AlgoliaHttpRequester.cs
+++ b/src/Algolia.Search/Http/AlgoliaHttpRequester.cs
@@ -129,7 +129,7 @@ namespace Algolia.Search.Http
             {
                 // HttpRequestException is thrown when an underlying issue happened such as
                 // network connectivity, DNS failure, server certificate validation.
-                return new AlgoliaHttpResponse { IsNetworkError = true, Error = e.ToString() };
+                return new AlgoliaHttpResponse { IsNetworkError = true, Error = e.Message };
             }
         }
 

--- a/src/Algolia.Search/Transport/HttpTransport.cs
+++ b/src/Algolia.Search/Transport/HttpTransport.cs
@@ -137,7 +137,7 @@ namespace Algolia.Search.Transport
                 }
             }
 
-            throw new AlgoliaUnreachableHostException("RetryStrategy failed to connect to Algolia. Reason:" + errorMessage);
+            throw new AlgoliaUnreachableHostException("RetryStrategy failed to connect to Algolia. Reason: " + errorMessage);
         }
 
         /// <summary>

--- a/src/Algolia.Search/Transport/HttpTransport.cs
+++ b/src/Algolia.Search/Transport/HttpTransport.cs
@@ -48,6 +48,7 @@ namespace Algolia.Search.Transport
         private readonly ISerializer _serializer;
         private readonly RetryStrategy _retryStrategy;
         private readonly AlgoliaConfig _algoliaConfig;
+        private string error;
 
         /// <summary>
         /// Instantiate the transport class with the given configuratio and requester
@@ -123,6 +124,8 @@ namespace Algolia.Search.Transport
                     .SendRequestAsync(request, requestTimeout, ct)
                     .ConfigureAwait(false);
 
+                error = response.Error;
+
                 switch (_retryStrategy.Decide(host, response))
                 {
                     case RetryOutcomeType.Success:
@@ -134,7 +137,7 @@ namespace Algolia.Search.Transport
                 }
             }
 
-            throw new AlgoliaUnreachableHostException("Unreachable hosts");
+            throw new AlgoliaUnreachableHostException(error);
         }
 
         /// <summary>

--- a/src/Algolia.Search/Transport/HttpTransport.cs
+++ b/src/Algolia.Search/Transport/HttpTransport.cs
@@ -48,7 +48,7 @@ namespace Algolia.Search.Transport
         private readonly ISerializer _serializer;
         private readonly RetryStrategy _retryStrategy;
         private readonly AlgoliaConfig _algoliaConfig;
-        private string error;
+        private string errorMessage;
 
         /// <summary>
         /// Instantiate the transport class with the given configuratio and requester
@@ -124,7 +124,7 @@ namespace Algolia.Search.Transport
                     .SendRequestAsync(request, requestTimeout, ct)
                     .ConfigureAwait(false);
 
-                error = response.Error;
+                errorMessage = response.Error;
 
                 switch (_retryStrategy.Decide(host, response))
                 {
@@ -137,7 +137,7 @@ namespace Algolia.Search.Transport
                 }
             }
 
-            throw new AlgoliaUnreachableHostException(error);
+            throw new AlgoliaUnreachableHostException("RetryStrategy failed to connect to Algolia. Reason:" + errorMessage);
         }
 
         /// <summary>


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no   
| BC breaks?        | no     
| Related Issue     | Fix #737  <!-- will close issue automatically, if any -->
| Need Doc update   | no


## Describe your change

- Send Error message to the transport layer
- Save last error message and add it in the Exception

## What problem is this fixing?

When all hosts are down the SDK sends the All hosts are unreachable message which is unclear. We would like to send the underlying error message to ease debugging.