### PR TITLE
Fix: TestApiKey flakiness

### DIFF
--- a/src/Algolia.Search.Test/EndToEnd/Client/ApiKeysTest.cs
+++ b/src/Algolia.Search.Test/EndToEnd/Client/ApiKeysTest.cs
@@ -86,7 +86,7 @@ namespace Algolia.Search.Test.EndToEnd.Client
                 }
                 catch (AlgoliaApiException e)
                 {
-                    shouldRetry = e.HttpErrorCode == 404 && e.Message.Contains("Key already exists");
+                    shouldRetry = e.HttpErrorCode == 404 || e.Message.Contains("Key already exists");
                 }
                 return shouldRetry;
             }, TimeSpan.FromSeconds(1), 10);

--- a/src/Algolia.Search.Test/EndToEnd/Client/ApiKeysTest.cs
+++ b/src/Algolia.Search.Test/EndToEnd/Client/ApiKeysTest.cs
@@ -86,10 +86,10 @@ namespace Algolia.Search.Test.EndToEnd.Client
                 }
                 catch (AlgoliaApiException e)
                 {
-                    shouldRetry = e.HttpErrorCode == 404 || e.Message.Contains("Key already exists");
+                    shouldRetry = e.HttpErrorCode == 404 && e.Message.Contains("Key already exists");
                 }
                 return shouldRetry;
-            }, TimeSpan.FromSeconds(1), 10);
+            }, TimeSpan.FromSeconds(1), 30);
 
             await BaseTest.SearchClient.GetApiKeyAsync(_apiKey);
 

--- a/src/Algolia.Search.Test/EndToEnd/Client/ApiKeysTest.cs
+++ b/src/Algolia.Search.Test/EndToEnd/Client/ApiKeysTest.cs
@@ -86,7 +86,7 @@ namespace Algolia.Search.Test.EndToEnd.Client
                 }
                 catch (AlgoliaApiException e)
                 {
-                    shouldRetry = e.HttpErrorCode == 404 && e.Message == "Key already exists";
+                    shouldRetry = e.HttpErrorCode == 404 && e.Message.Contains("Key already exists");
                 }
                 return shouldRetry;
             }, TimeSpan.FromSeconds(1), 10);


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no    
| Related Issue     | Fix #734 <!-- will close issue automatically, if any -->
| Need Doc update   | no


## Describe your change

This pull request is related to our API Key test that is flaky. 

![Screenshot 2020-10-30 at 16 56 35](https://user-images.githubusercontent.com/23667211/97727596-e3a9ae00-1ad0-11eb-94f1-57c7041c3df2.png)


## What problem is this fixing?

This is fixing our Test suits issues where we need to run multiple time our CI or our local test before this test pass. 
