### PR TITLE
feat(analytics): add tracked search count

### DIFF
--- a/src/Algolia.Search.Test/EndToEnd/Analytics/AnalyticsAbTest.cs
+++ b/src/Algolia.Search.Test/EndToEnd/Analytics/AnalyticsAbTest.cs
@@ -86,14 +86,14 @@ namespace Algolia.Search.Test.EndToEnd.Analytics
 
             ABTest abTestToCheck = await BaseTest.AnalyticsClient.GetABTestAsync(abTest.AbTestId.Value);
             Assert.IsTrue(TestHelper.AreObjectsEqual(abTestToCheck, abTest, "CreatedAt", "Status", "ClickCount",
-                "ConversionCount"));
+                "ConversionCount", "TrackedSearchCount"));
             Assert.That(abTestToCheck.Status, Is.EqualTo("active"));
 
             ABTestsResponse listAbTests = await BaseTest.AnalyticsClient.GetABTestsAsync();
             Assert.IsTrue(listAbTests.ABTests.Any(x => x.AbTestId == abTest.AbTestId));
             Assert.IsTrue(TestHelper.AreObjectsEqual(
                 listAbTests.ABTests.FirstOrDefault(x => x.AbTestId == abTest.AbTestId), abTest, "CreatedAt", "Status",
-                "ClickCount", "ConversionCount"));
+                "ClickCount", "ConversionCount", "TrackedSearchCount"));
 
             await BaseTest.AnalyticsClient.StopABTestAsync(abTest.AbTestId.Value);
 

--- a/src/Algolia.Search/Models/Analytics/Variant.cs
+++ b/src/Algolia.Search/Models/Analytics/Variant.cs
@@ -89,5 +89,10 @@ namespace Algolia.Search.Models.Analytics
         /// Search parameters for AA Testing
         /// </summary>
         public Query CustomSearchParameters { get; set; }
+
+        /// <summary>
+        /// Tracked search count
+        /// </summary>
+        public int? TrackedSearchCount { get; set; }
     }
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes  <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | Fix [#142](https://github.com/algolia/algoliasearch-client-specs-internal/pull/142)  <!-- will close issue automatically, if any -->
| Need Doc update   | no ( already done )


## Describe your change

Add the field trackedSearchCount to AB testing metrics returned.
