### PR TITLE
fix(transport): MemoryStream disposed betweem two retryStrategy call

### DIFF
--- a/src/Algolia.Search.Test/RetryStrategyTest/RetryStrategyTest.cs
+++ b/src/Algolia.Search.Test/RetryStrategyTest/RetryStrategyTest.cs
@@ -53,23 +53,25 @@ namespace Algolia.Search.Test.RetryStrategyTest
             var hosts = new List<StatefulHost>
             {
                 // Bad host, will fail with
-                // System.Net.Http.HttpRequestException: nodename nor servname provided, or not known
+                // System.Net.Http.HttpRequestException:
+                // The SSL connection could not be established, see inner exception. ---> System.Security.Authentication.AuthenticationException:
                 new StatefulHost
                 {
-                    Url = $"{TestHelper.ApplicationId1}-1.algolianet.co",
+                    Url = "expired.badssl.com",
                     Up = true,
                     LastUse = DateTime.UtcNow,
                     Accept = CallType.Read | CallType.Write,
                 },
                 new StatefulHost
                 {
-                    Url = $"{TestHelper.ApplicationId1}-2.algolianet.com",
+                    Url = $"{TestHelper.ApplicationId1}-dsn.algolia.net",
                     Up = true,
                     LastUse = DateTime.UtcNow,
                     Accept = CallType.Read | CallType.Write,
                 }
             };
 
+            // Warning /!\ Only use search key here /!\
             SearchConfig config = new SearchConfig(TestHelper.ApplicationId1, TestHelper.SearchKey1)
             {
                 CustomHosts = hosts

--- a/src/Algolia.Search.Test/RetryStrategyTest/RetryStrategyTest.cs
+++ b/src/Algolia.Search.Test/RetryStrategyTest/RetryStrategyTest.cs
@@ -29,6 +29,7 @@ using System.Threading.Tasks;
 using Algolia.Search.Clients;
 using Algolia.Search.Http;
 using Algolia.Search.Models.Enums;
+using Algolia.Search.Models.Search;
 using Algolia.Search.Transport;
 using NUnit.Framework;
 
@@ -38,6 +39,48 @@ namespace Algolia.Search.Test.RetryStrategyTest
     [Parallelizable]
     public class RetryStrategyTest
     {
+        [Test]
+        [Parallelizable]
+        public async Task TestRetryStrategyEndToEnd()
+        {
+            // Create a index with a valid client
+            var indexName = TestHelper.GetTestIndexName("test_retry_e2e");
+            var index = BaseTest.SearchClient.InitIndex(indexName);
+            var res = await index.SaveObjectAsync(new { title = "title" }, autoGenerateObjectId: true);
+            res.Wait();
+
+            // Create a client with a bad host to test that the retry worked as expected
+            var hosts = new List<StatefulHost>
+            {
+                // Bad host, will fail with
+                // System.Net.Http.HttpRequestException: nodename nor servname provided, or not known
+                new StatefulHost
+                {
+                    Url = $"{TestHelper.ApplicationId1}-1.algolianet.co",
+                    Up = true,
+                    LastUse = DateTime.UtcNow,
+                    Accept = CallType.Read | CallType.Write,
+                },
+                new StatefulHost
+                {
+                    Url = $"{TestHelper.ApplicationId1}-2.algolianet.com",
+                    Up = true,
+                    LastUse = DateTime.UtcNow,
+                    Accept = CallType.Read | CallType.Write,
+                }
+            };
+
+            SearchConfig config = new SearchConfig(TestHelper.ApplicationId1, TestHelper.SearchKey1)
+            {
+                CustomHosts = hosts
+            };
+            var client = new SearchClient(config);
+            var idx = client.InitIndex(indexName);
+
+            var search = await idx.SearchAsync<Object>(new Query(""));
+            Assert.AreEqual(1, search.NbHits);
+        }
+
         [TestCase(CallType.Read)]
         [TestCase(CallType.Write)]
         [Parallelizable]

--- a/src/Algolia.Search/Transport/HttpTransport.cs
+++ b/src/Algolia.Search/Transport/HttpTransport.cs
@@ -113,10 +113,9 @@ namespace Algolia.Search.Transport
                 Compression = _algoliaConfig.Compression
             };
 
-            request.Body = CreateRequestContent(data, request.CanCompress);
-
             foreach (var host in _retryStrategy.GetTryableHost(callType))
             {
+                request.Body = CreateRequestContent(data, request.CanCompress);
                 request.Uri = BuildUri(host.Url, uri, requestOptions?.QueryParameters);
                 int requestTimeout = (requestOptions?.Timeout ?? GetTimeOut(callType)) * (host.RetryCount + 1);
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | YES
| New feature?      | no
| BC breaks?        | no     
| Need Doc update   | no

## What?

Following on a expired certificate issue on one of `-dsn` domains, we noticed that in some cases, the C# client wasn't able to correctly retry a failing call. 

In that case the exception sent was:

```
System.Net.Http.HttpRequestException: The SSL connection could not be established, see inner exception. 
---> System.Security.Authentication.AuthenticationException: 
The remote certificate is invalid according to the validation procedure.
```

This SSL exception thrown by the `httpClient` was correctly catched and marked as a retryable failure by the strategy, but the following retry calls failed with the following exception:

```
System.Net.Http.HttpRequestException: Error while copying content to a stream.
 ---> System.ObjectDisposedException: Cannot access a closed Stream.
   at System.IO.StreamHelpers.ValidateCopyToArgs(Stream source, Stream destination, Int32 bufferSize)
``` 

This exception means that the `httpClient` wasn't able to read the stream that should be sent to the API. After some investigations I found out the reasons:

In the transport layer we create a `MemoryStream` **before** the retryStrategy loop:

https://github.com/algolia/algoliasearch-client-csharp/blob/c1f684e57eaee4b7c59874e5e5d1a9134714cc50/src/Algolia.Search/Transport/HttpTransport.cs#L116-L121

Then the retry calls the `SendRequest` method which does the following:

Gives the stream to `httpRequestMessage`:

https://github.com/algolia/algoliasearch-client-csharp/blob/c1f684e57eaee4b7c59874e5e5d1a9134714cc50/src/Algolia.Search/Http/AlgoliaHttpRequester.cs#L76-L81

Wrap the `httpRequestMessage` in a `using block`:

https://github.com/algolia/algoliasearch-client-csharp/blob/c1f684e57eaee4b7c59874e5e5d1a9134714cc50/src/Algolia.Search/Http/AlgoliaHttpRequester.cs#L93

And this is where the issue happens:

The stream created in the TransportLayer before the loop is **not copied** and thus `HttpRequestMessage` is taking ownership of it with the [new StreamContent()](https://docs.microsoft.com/en-us/dotnet/api/system.net.http.streamcontent.-ctor?view=net-5.0#System_Net_Http_StreamContent__ctor_System_IO_Stream_) ctor.

**Thus, at the end of the `using` block the stream will be closed/disposed and not available for further usages!** Which explains why the following calls failed. 

### Impact?

User using the client with only one `POST` method (methods having a stream/body to send like the search one) would have the call failed in loop because:

-> call n1 to `-dsn` with SSL expired. Retryable but dispose the `Stream`
-> call n2 to `-1` with the stream closed => throw a `HttpException` because of the closed stream => retryable
-> call n3 to `-2` with the stream closed => throw a `HttpException` because of the closed stream => retryable
-> call n4 to `-3` with the stream closed => throw a `HttpException` because of the closed stream => retryable

-> End with all the host marked as down..

On the other hand, if the `client` is used to target other endpoint such as `get` one, the get method will mark the `-dsn` as down for the other calls, making it possible for them to succeed. 

## How?

- Simply re-creating the Stream for each retryStrategy call instead of re-using it.

## Test strategy

- Added a `e2e` test for the retryStrategy checking that the client correctly retries and that the MemoryStream is available.
- Non regressions on existing tests

## Documentation

- https://docs.microsoft.com/en-us/dotnet/api/system.net.http.streamcontent.-ctor?view=net-5.0#System_Net_Http_StreamContent__ctor_System_IO_Stream_



