### PR TITLE
feat(serializer): JsonSerializer re-usable instance

### DIFF
--- a/src/Algolia.Search/Serializer/DefaultSerializer.cs
+++ b/src/Algolia.Search/Serializer/DefaultSerializer.cs
@@ -40,8 +40,8 @@ namespace Algolia.Search.Serializer
 
         private static readonly int DefaultBufferSize = 1024;
 
-        // Re-usable Serializer instance, so it keeps in memory the JsonSerializationContract 
-        private static JsonSerializer Serializer = JsonSerializer.Create(JsonConfig.AlgoliaJsonSerializerSettings);
+        // Re-usable Serializer instance, so it keeps in memory the JsonSerializationContract
+        private static readonly JsonSerializer Serializer = JsonSerializer.Create(JsonConfig.AlgoliaJsonSerializerSettings);
 
         // Buffer sized as recommended by Bradley Grainger, http://faithlife.codes/blog/2012/06/always-wrap-gzipstream-with-bufferedstream/
         private static readonly int GZipBufferSize = 8192;

--- a/src/Algolia.Search/Serializer/DefaultSerializer.cs
+++ b/src/Algolia.Search/Serializer/DefaultSerializer.cs
@@ -40,6 +40,9 @@ namespace Algolia.Search.Serializer
 
         private static readonly int DefaultBufferSize = 1024;
 
+        // Re-usable Serializer instance, so it keeps in memory the JsonSerializationContract 
+        private static JsonSerializer Serializer = JsonSerializer.Create(JsonConfig.AlgoliaJsonSerializerSettings);
+
         // Buffer sized as recommended by Bradley Grainger, http://faithlife.codes/blog/2012/06/always-wrap-gzipstream-with-bufferedstream/
         private static readonly int GZipBufferSize = 8192;
 
@@ -65,8 +68,7 @@ namespace Algolia.Search.Serializer
 
             void JsonSerialize(JsonTextWriter writer)
             {
-                JsonSerializer serializer = JsonSerializer.Create(JsonConfig.AlgoliaJsonSerializerSettings);
-                serializer.Serialize(writer, data);
+                Serializer.Serialize(writer, data);
                 writer.Flush();
             }
         }
@@ -80,8 +82,7 @@ namespace Algolia.Search.Serializer
             using (var sr = new StreamReader(stream))
             using (var jtr = new JsonTextReader(sr))
             {
-                JsonSerializer serializer = JsonSerializer.Create(JsonConfig.AlgoliaJsonSerializerSettings);
-                return serializer.Deserialize<T>(jtr);
+                return Serializer.Deserialize<T>(jtr);
             }
         }
     }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| BC breaks?        | no     
| Need Doc update   | no

## Describe your change

In `src/Algolia.Search/Serializer/DefaultSerializer.cs`, let's have a re-usable instance of `JsonSerializer`  instead of a creating one for each call.  This will allow NewtonSoft to re-use  `JsonContract` instead of recreating one for each call.

## What problem is this fixing?

Performance issue under high load. See perf impact before and after the fix:

Before:

![DOTTRACE_BEFORE](https://user-images.githubusercontent.com/22633119/103530870-817e7800-4e88-11eb-955e-ee47044ac368.png)

After:

![DOTTRACE_AFTER](https://user-images.githubusercontent.com/22633119/103530876-83483b80-4e88-11eb-9c93-0f38dfeaa9c2.png)
