### PR TITLE
fix: return interface ISearchIndex instead of object

### DIFF
--- a/src/Algolia.Search/Clients/SearchClient.cs
+++ b/src/Algolia.Search/Clients/SearchClient.cs
@@ -105,7 +105,7 @@ namespace Algolia.Search.Clients
         /// Initialize an index for the given client
         /// </summary>
         /// <param name="indexName">Your index name</param>
-        public SearchIndex InitIndex(string indexName)
+        public ISearchIndex InitIndex(string indexName)
         {
             return string.IsNullOrWhiteSpace(indexName)
                 ? throw new ArgumentNullException(nameof(indexName), "The Index name is required")


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    
| BC breaks?        | no     
| Related Issue     | Fix #745   <!-- will close issue automatically, if any -->
| Need Doc update   | yes/no


## Describe your change

update InitIndex method returning interface instead of Object

## What problem is this fixing?

Users will be able to mock correctly SearchIndex 
