### PR TITLE
Allow submitting batches that make changes to multiple indexes and multiple types at once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - feat(analytics): add tracked search count c1f684e57eaee4b7c59874e5e5d1a9134714cc50
 - tests: Add delete by tag CTS test 6e775d90721e1e035e8eb3f68ea0124b5220c8e0
+- feat(client): allow atomic base changes to multiple typed indexes at once
 
 ### Fix
 

--- a/src/Algolia.Search.Test/EndToEnd/Index/BatchingTest.cs
+++ b/src/Algolia.Search.Test/EndToEnd/Index/BatchingTest.cs
@@ -109,15 +109,15 @@ namespace Algolia.Search.Test.EndToEnd.Index
 
             Assert.That(objectsFromIterator, Has.Exactly(6).Items);
             Assert.True(TestHelper.AreObjectsEqual(objectsFromIterator.Find(r => r.ObjectID.Equals("zero")),
-                operations.Find(r => r.BodyTyped.ObjectID.Equals("zero")).Body));
+                operations.Find(r => r.Body.ObjectID.Equals("zero")).Body));
             Assert.True(TestHelper.AreObjectsEqual(objectsFromIterator.Find(r => r.ObjectID.Equals("one")),
-                operations.Find(r => r.BodyTyped.ObjectID.Equals("one")).Body));
+                operations.Find(r => r.Body.ObjectID.Equals("one")).Body));
             Assert.True(TestHelper.AreObjectsEqual(objectsFromIterator.Find(r => r.ObjectID.Equals("two")),
-                operations.Find(r => r.BodyTyped.ObjectID.Equals("two")).Body));
+                operations.Find(r => r.Body.ObjectID.Equals("two")).Body));
             Assert.True(TestHelper.AreObjectsEqual(objectsFromIterator.Find(r => r.ObjectID.Equals("two_bis")),
-                operations.Find(r => r.BodyTyped.ObjectID.Equals("two_bis")).Body));
+                operations.Find(r => r.Body.ObjectID.Equals("two_bis")).Body));
             Assert.True(TestHelper.AreObjectsEqual(objectsFromIterator.Find(r => r.ObjectID.Equals("three")),
-                operations.Find(r => r.BodyTyped.ObjectID.Equals("three")).Body));
+                operations.Find(r => r.Body.ObjectID.Equals("three")).Body));
             Assert.True(TestHelper.AreObjectsEqual(objectsFromIterator.Find(r => r.ObjectID.Equals("five")),
                 batchOne.Find(r => r.ObjectID.Equals("five"))));
             Assert.False(objectsFromIterator.Exists(x => x.ObjectID.Equals("four")));

--- a/src/Algolia.Search/Clients/ISearchIndex.cs
+++ b/src/Algolia.Search/Clients/ISearchIndex.cs
@@ -217,6 +217,42 @@ namespace Algolia.Search.Clients
             CancellationToken ct = default) where T : class;
 
         /// <summary>
+        /// Batch the given request
+        /// </summary>
+        /// <param name="operations">Operations to send to the api</param>
+        /// <param name="requestOptions">Add extra http header or query parameters to Algolia</param>
+        /// <returns></returns>
+        BatchResponse Batch(IEnumerable<BatchOperation> operations, RequestOptions requestOptions = null);
+
+        /// <summary>
+        /// Perform several indexing operations in one API call.
+        /// </summary>
+        /// <param name="operations">Operations to send to the api</param>
+        /// <param name="requestOptions">Add extra http header or query parameters to Algolia</param>
+        /// <param name="ct">Optional cancellation token</param>
+        /// <returns></returns>
+        Task<BatchResponse> BatchAsync(IEnumerable<BatchOperation> operations,
+            RequestOptions requestOptions = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Perform several indexing operations in one API call.
+        /// </summary>
+        /// <param name="request">Request to send to the api</param>
+        /// <param name="requestOptions">Add extra http header or query parameters to Algolia</param>
+        /// <returns></returns>
+        BatchResponse Batch(BatchRequest request, RequestOptions requestOptions = null);
+
+        /// <summary>
+        /// Perform several indexing operations in one API call.
+        /// </summary>
+        /// <param name="request">Batch request</param>
+        /// <param name="requestOptions">Add extra http header or query parameters to Algolia</param>
+        /// <param name="ct">Optional cancellation token</param>
+        /// <returns></returns>
+        Task<BatchResponse> BatchAsync(BatchRequest request, RequestOptions requestOptions = null,
+            CancellationToken ct = default);
+
+        /// <summary>
         /// Remove objects from an index using their object ids.
         /// </summary>
         /// <param name="objectId">Algolia's objectID</param>

--- a/src/Algolia.Search/Clients/SearchIndex.cs
+++ b/src/Algolia.Search/Clients/SearchIndex.cs
@@ -267,6 +267,52 @@ namespace Algolia.Search.Clients
         public BatchResponse Batch<T>(BatchRequest<T> request, RequestOptions requestOptions = null) where T : class =>
             AsyncHelper.RunSync(() => BatchAsync(request, requestOptions));
 
+
+
+
+
+        /// <inheritdoc />
+        public BatchResponse Batch(IEnumerable<BatchOperation> operations, RequestOptions requestOptions = null) =>
+            AsyncHelper.RunSync(() => BatchAsync(operations, requestOptions));
+
+        /// <inheritdoc />
+        public async Task<BatchResponse> BatchAsync(IEnumerable<BatchOperation> operations,
+            RequestOptions requestOptions = null, CancellationToken ct = default)
+        {
+            if (operations == null)
+            {
+                throw new ArgumentNullException(nameof(operations));
+            }
+
+            var batch = new BatchRequest(operations);
+
+            return await BatchAsync(batch, requestOptions, ct).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public BatchResponse Batch(BatchRequest request, RequestOptions requestOptions = null) =>
+            AsyncHelper.RunSync(() => BatchAsync(request, requestOptions));
+
+
+        /// <inheritdoc />
+        public async Task<BatchResponse> BatchAsync(BatchRequest request, RequestOptions requestOptions = null,
+            CancellationToken ct = default)
+        {
+            if (request == null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
+
+            BatchResponse response = await _transport.ExecuteRequestAsync<BatchResponse, BatchRequest>(
+                    HttpMethod.Post, $"/1/indexes/{_urlEncodedIndexName}/batch", CallType.Write, request,
+                    requestOptions,
+                    ct)
+                .ConfigureAwait(false);
+
+            response.WaitTask = t => WaitTask(t);
+            return response;
+        }
+
         /// <summary>
         /// Split records into smaller chunks before sending them to the API
         /// </summary>

--- a/src/Algolia.Search/Models/Batch/BatchOperation.cs
+++ b/src/Algolia.Search/Models/Batch/BatchOperation.cs
@@ -26,7 +26,7 @@ namespace Algolia.Search.Models.Batch
     /// <summary>
     /// Represent an algolia batch object
     /// </summary>
-    public class BatchOperation<T> where T : class
+    public class BatchOperation
     {
         /// <summary>
         /// Type of batch see <see cref="Enums.BatchActionType"/>
@@ -41,6 +41,28 @@ namespace Algolia.Search.Models.Batch
         /// <summary>
         /// Body of the batch, objects you want to send
         /// </summary>
-        public T Body { get; set; }
+        public object Body { get; set; }
+    }
+
+    /// <summary>
+    /// Represent an algolia batch object
+    /// </summary>
+    public class BatchOperation<T>: BatchOperation
+        where T : class
+    {
+        /// <summary>
+        /// Body of the batch, objects you want to send, typed
+        /// </summary>
+        public T BodyTyped
+        {
+            get
+            {
+                return Body as T;
+            }
+            set
+            {
+                Body = value;
+            }
+        }
     }
 }

--- a/src/Algolia.Search/Models/Batch/BatchOperation.cs
+++ b/src/Algolia.Search/Models/Batch/BatchOperation.cs
@@ -53,15 +53,15 @@ namespace Algolia.Search.Models.Batch
         /// <summary>
         /// Body of the batch, objects you want to send, typed
         /// </summary>
-        public T BodyTyped
+        public new T Body
         {
             get
             {
-                return Body as T;
+                return base.Body as T;
             }
             set
             {
-                Body = value;
+                base.Body = value;
             }
         }
     }

--- a/src/Algolia.Search/Models/Batch/BatchRequest.cs
+++ b/src/Algolia.Search/Models/Batch/BatchRequest.cs
@@ -31,6 +31,52 @@ namespace Algolia.Search.Models.Batch
     /// <summary>
     /// Batch request for algoli'as API
     /// </summary>
+    public class BatchRequest
+    {
+        /// <summary>
+        /// Create a new batch request with operations
+        /// </summary>
+        /// <param name="operations"></param>
+        public BatchRequest(IEnumerable<BatchOperation> operations)
+        {
+            if (operations == null)
+            {
+                throw new ArgumentNullException(nameof(operations));
+            }
+
+            Operations = operations.ToList();
+        }
+
+        /// <summary>
+        /// Create a new batch request with action type and data
+        /// </summary>
+        /// <param name="actionType">Batch Action Type</param>
+        /// <param name="data">Data to send</param>
+        public BatchRequest(string actionType, IEnumerable<object> data)
+        {
+            if (data == null)
+            {
+                throw new ArgumentNullException(nameof(data));
+            }
+
+            Operations = new List<BatchOperation>();
+
+            foreach (var item in data)
+            {
+                Operations.Add(new BatchOperation { Action = actionType, Body = item });
+            }
+        }
+
+        /// <summary>
+        /// List of operations of the batch request
+        /// </summary>
+        [JsonProperty(PropertyName = "requests")]
+        public ICollection<BatchOperation> Operations { get; set; }
+    }
+
+    /// <summary>
+    /// Batch request for algoli'as API
+    /// </summary>
     public class BatchRequest<T> where T : class
     {
         /// <summary>


### PR DESCRIPTION
*NOTE*: I cannot find documentation whether this functionality is supported by the API. The presence of the "IndexName" property on the `BatchOperation` class indicates, to me, that any index could be specified and the data could be sent to that index. Since Algolia is schemaless, I personally cannot see a reason why it would be disallowed, but perhaps that IndexName was only intended for replicas of the base index. However, The fact that the `Batch()` methods are present on the `SearchIndex` and not on the client object suggests to me that my assumption may be incorrect. If I am incorrect, then this functionality I wish for is impossible and this can be closed.

I was unable to run the unit tests myself, so I'm opening a PR to let the CI test it.

| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no      
| Related Issue     |   <!-- will close issue automatically, if any -->
| Need Doc update   | yes


## Describe your change

Presently, the `Batch()` methods require a specific type to be specified. This means you could only batch changes to a single index type at once. This change removes that requirement and allows you to specify a batch across multiple types and indexes.

## What problem is this fixing?

Now, you can call a batch update to multiple indexes and multiple data types at once.

Before:
```
var operation1 = new List<BatchOperation<ObjectToBatch>
{
    new BatchOperation<ObjectToBatch>
    {
        Action = BatchActionType.UpdateObject,
        Body = new ObjectToBatch { ObjectID = "one", Key = "v" }
    }
};
var operation2 = new List<BatchOperation<ObjectToBatch2>
{
    new BatchOperation<ObjectToBatch2>
    {
        Action = BatchActionType.UpdateObject,
        Body = new ObjectToBatch2 { ObjectID = "two", Key = "v" },
    }
};

var batchOneResponse = await _index.BatchAsync(operation1);
batchTwoResponse.Wait();

var batchTwoResponse = await _index.BatchAsync(operation2);
batchTwoResponse.Wait();
```

Since the two batches would need to be called separately, you cannot do atomic changes to two typed indexes at once, which could lead to issues if one update fails.

Now:
e.g. 
```
var operations = new List<BatchOperation>
{
    new BatchOperation
    {
        Action = BatchActionType.UpdateObject,
        Body = new ObjectToBatch { ObjectID = "one", Key = "v" },
        IndexName = Index1Name,
    },
    new BatchOperation
    {
        Action = BatchActionType.UpdateObject,
        Body = new ObjectToBatch2 { ObjectID = "two", Key = "v" },
        IndexName = Index2Name,
    },
};

var batchTwoResponse = await _index.BatchAsync(operations);
batchTwoResponse.Wait();
```

This allows you to make atomic changes to arbitrary indexes.
