### PR TITLE
Fix : delete index method to be waitable

### DIFF
--- a/src/Algolia.Search/Clients/SearchIndex.cs
+++ b/src/Algolia.Search/Clients/SearchIndex.cs
@@ -368,9 +368,12 @@ namespace Algolia.Search.Clients
         public async Task<DeleteResponse> DeleteAsync(RequestOptions requestOptions = null,
             CancellationToken ct = default)
         {
-            return await _transport.ExecuteRequestAsync<DeleteResponse>(HttpMethod.Delete,
+            DeleteResponse response = await _transport.ExecuteRequestAsync<DeleteResponse>(HttpMethod.Delete,
                     $"/1/indexes/{_urlEncodedIndexName}", CallType.Write, requestOptions, ct)
                 .ConfigureAwait(false);
+
+            response.WaitTask = t => WaitTask(t);
+            return response;
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | Fix #757  <!-- will close issue automatically, if any -->
| Need Doc update   | no


## Describe your change

- Instantiate DeleteResponse and wait on it

- Add tests

## What problem is this fixing?

Calling Index.Delete().Wait() throws null reference exception.
