### PR TITLE
feat(indices: add missing field to IndicesResponse

### DIFF
--- a/src/Algolia.Search/Models/Common/ListIndicesResponse.cs
+++ b/src/Algolia.Search/Models/Common/ListIndicesResponse.cs
@@ -78,6 +78,16 @@ namespace Algolia.Search.Models.Common
         public int LastBuildTimes { get; set; }
 
         /// <summary>
+        /// Name of primary index.
+        /// </summary>
+        public String Primary { get; set; }
+
+        /// <summary>
+        /// List of replicas attach to the index
+        /// </summary>
+        public List<String> Replicas { get; set; }
+
+        /// <summary>
         /// Number of pending indexing operations.
         /// </summary>
         public int NumberOfPendingTasks { get; set; }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      |yes    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Need Doc update   | no


## Describe your change

Adds missing fields to `IndicesResponse`:
- [x] `replicas`
- [x] `primary`
