### PR TITLE
feat(settings): relevant sorting

### DIFF
--- a/src/Algolia.Search/Models/Search/Query.cs
+++ b/src/Algolia.Search/Models/Search/Query.cs
@@ -414,7 +414,7 @@ namespace Algolia.Search.Models.Search
         /// Bigger value means less, but more relevant results, 
         /// lesser value - more less relevant results
         /// </summary>
-        public int RelevancyStrictness { get; set; }
+        public int? RelevancyStrictness { get; set; }
 
         /// <summary>
         /// Returns the Query as a query string

--- a/src/Algolia.Search/Models/Search/Query.cs
+++ b/src/Algolia.Search/Models/Search/Query.cs
@@ -410,6 +410,13 @@ namespace Algolia.Search.Models.Search
         public IDictionary<string, object> CustomParameters { get; set; }
 
         /// <summary>
+        /// Relevancy score to apply to search in virtual index. 
+        /// Bigger value means less, but more relevant results, 
+        /// lesser value - more less relevant results
+        /// </summary>
+        public int RelevancyStrictness { get; set; }
+
+        /// <summary>
         /// Returns the Query as a query string
         /// Example : "query= distinct=0"
         /// </summary>

--- a/src/Algolia.Search/Models/Search/SearchResponse.cs
+++ b/src/Algolia.Search/Models/Search/SearchResponse.cs
@@ -173,5 +173,15 @@ namespace Algolia.Search.Models.Search
         /// Rules applied to the query
         /// </summary>
         public IEnumerable<Dictionary<string, object>> AppliedRules { get; set; }
+
+        /// <summary>
+        /// Relevancy score to apply to the search in virtual index.
+        /// </summary>
+        public int AppliedRelevancyStrictness { get; set; }
+
+        /// <summary>
+        /// Number of relevant hits to display in case of non-zero relevancyStrictness applied
+        /// </summary>
+        public int NbSortedHits { get; set; }
     }
 }

--- a/src/Algolia.Search/Models/Search/SearchResponse.cs
+++ b/src/Algolia.Search/Models/Search/SearchResponse.cs
@@ -177,11 +177,11 @@ namespace Algolia.Search.Models.Search
         /// <summary>
         /// Relevancy score to apply to the search in virtual index.
         /// </summary>
-        public int AppliedRelevancyStrictness { get; set; }
+        public int? AppliedRelevancyStrictness { get; set; }
 
         /// <summary>
         /// Number of relevant hits to display in case of non-zero relevancyStrictness applied
         /// </summary>
-        public int NbSortedHits { get; set; }
+        public int? NbSortedHits { get; set; }
     }
 }

--- a/src/Algolia.Search/Models/Settings/IndexSettings.cs
+++ b/src/Algolia.Search/Models/Settings/IndexSettings.cs
@@ -89,7 +89,7 @@ namespace Algolia.Search.Models.Settings
         /// Bigger value means less, but more relevant results, 
         /// lesser value - more less relevant results
         /// </summary>
-        public int RelevancyStrictness { get; set; }
+        public int? RelevancyStrictness { get; set; }
 
         /// <summary>
         /// The primary parameter is automatically added to a replica's settings when the replica is created and cannot be modified.

--- a/src/Algolia.Search/Models/Settings/IndexSettings.cs
+++ b/src/Algolia.Search/Models/Settings/IndexSettings.cs
@@ -85,6 +85,13 @@ namespace Algolia.Search.Models.Settings
         public List<string> Replicas { get; set; }
 
         /// <summary>
+        /// Relevancy score to apply to search in virtual index. 
+        /// Bigger value means less, but more relevant results, 
+        /// lesser value - more less relevant results
+        /// </summary>
+        public int RelevancyStrictness { get; set; }
+
+        /// <summary>
         /// The primary parameter is automatically added to a replica's settings when the replica is created and cannot be modified.
         /// </summary>
         [JsonProperty]


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | Fix #759   <!-- will close issue automatically, if any -->
| Need Doc update   | yes


## Describe your change

Search query &  index Settings parameters:
* **relevancyStrictness** 
  - integer value [0-100]  
  - relevancy score to apply to search in virtual index. Bigger value means less, but more relevant results, lesser value - more less relevant results

Search response:
* **appliedRelevancyStrictness** 
  - integer value [0-100]
  - relevancy score to apply to the search in virtual index. 
* **nbSortedHits** 
   - integer value
   - number of relevant hits to display in case of non-zero `relevancyStrictness` applied
