### PR TITLE
Fix: add custom setter for NumericAttributesForFiltering

### DIFF
--- a/src/Algolia.Search.Test/EndToEnd/Index/SettingsTest.cs
+++ b/src/Algolia.Search.Test/EndToEnd/Index/SettingsTest.cs
@@ -175,7 +175,6 @@ namespace Algolia.Search.Test.EndToEnd.Index
             settings.IgnorePlurals = new List<string> { "en", "fr" };
             settings.RemoveStopWords = new List<string> { "en", "fr" };
             settings.Distinct = true;
-
             var saveSettingsResponseAfterChanges = await _index.SetSettingsAsync(settings);
             saveSettingsResponseAfterChanges.Wait();
 
@@ -183,6 +182,15 @@ namespace Algolia.Search.Test.EndToEnd.Index
             spceficPropertiesCheck.AddRange(new List<string> { "TypoTolerance", "IgnorePlurals", "RemoveStopWords" });
             Assert.True(TestHelper.AreObjectsEqual(settings, getSettingsResponseAfterChanges,
                 spceficPropertiesCheck.ToArray()));
+
+            // Set new value for NumericAttributesForFiltering
+            settings.NumericAttributesForFiltering = null;
+
+            var saveSettingsResponseAfterChangesNumericAttributesForFiltering = await _index.SetSettingsAsync(settings);
+            saveSettingsResponseAfterChangesNumericAttributesForFiltering.Wait();
+
+            var getSettingsResponseAfterChangesNumericAttributesForFiltering = await _index.GetSettingsAsync();
+            Assert.AreEqual(null, getSettingsResponseAfterChangesNumericAttributesForFiltering.NumericAttributesForFiltering);
 
             // Check specific properties (couldn't be done by test helper)
             Assert.True((string)getSettingsResponseAfterChanges.TypoTolerance == (string)settings.TypoTolerance);
@@ -197,7 +205,6 @@ namespace Algolia.Search.Test.EndToEnd.Index
 
             // Check specific properties (couldn't be done by the helper)
             Assert.True(getSettingsResponse.AttributesToTransliterate.Contains("attribute2"));
-
         }
     }
 }

--- a/src/Algolia.Search.Test/EndToEnd/Index/SettingsTest.cs
+++ b/src/Algolia.Search.Test/EndToEnd/Index/SettingsTest.cs
@@ -156,11 +156,11 @@ namespace Algolia.Search.Test.EndToEnd.Index
             saveSettingsResponse.Wait();
 
             var getSettingsResponse = await _index.GetSettingsAsync();
-            var spceficPropertiesCheck = new List<string>
+            var specificPropertiesCheck = new List<string>
             {
                 "AlternativesAsExact", "DecompoundedAttributes", "CustomSettings", "UserData"
             };
-            Assert.True(TestHelper.AreObjectsEqual(settings, getSettingsResponse, spceficPropertiesCheck.ToArray()));
+            Assert.True(TestHelper.AreObjectsEqual(settings, getSettingsResponse, specificPropertiesCheck.ToArray()));
 
             // Check specific properties (couldn't be done by the helper)
             Assert.True(getSettingsResponse.DecompoundedAttributes.ContainsKey("de"));
@@ -179,9 +179,9 @@ namespace Algolia.Search.Test.EndToEnd.Index
             saveSettingsResponseAfterChanges.Wait();
 
             var getSettingsResponseAfterChanges = await _index.GetSettingsAsync();
-            spceficPropertiesCheck.AddRange(new List<string> { "TypoTolerance", "IgnorePlurals", "RemoveStopWords" });
+            specificPropertiesCheck.AddRange(new List<string> { "TypoTolerance", "IgnorePlurals", "RemoveStopWords" });
             Assert.True(TestHelper.AreObjectsEqual(settings, getSettingsResponseAfterChanges,
-                spceficPropertiesCheck.ToArray()));
+                specificPropertiesCheck.ToArray()));
 
             // Set new value for NumericAttributesForFiltering
             settings.NumericAttributesForFiltering = null;
@@ -191,6 +191,14 @@ namespace Algolia.Search.Test.EndToEnd.Index
 
             var getSettingsResponseAfterChangesNumericAttributesForFiltering = await _index.GetSettingsAsync();
             Assert.AreEqual(null, getSettingsResponseAfterChangesNumericAttributesForFiltering.NumericAttributesForFiltering);
+
+            settings.NumericAttributesForFiltering = new List<string> { "attribute1", "attribute2" };
+
+            var saveSettingsResponseAfterResetNumericAttributesForFiltering = await _index.SetSettingsAsync(settings);
+            saveSettingsResponseAfterChangesNumericAttributesForFiltering.Wait();
+
+            var getSettingsResponseAfterResetNumericAttributesForFiltering = await _index.GetSettingsAsync();
+            Assert.True(TestHelper.AreObjectsEqual(settings, getSettingsResponseAfterResetNumericAttributesForFiltering, specificPropertiesCheck.ToArray()));
 
             // Check specific properties (couldn't be done by test helper)
             Assert.True((string)getSettingsResponseAfterChanges.TypoTolerance == (string)settings.TypoTolerance);

--- a/src/Algolia.Search.Test/EndToEnd/Index/SettingsTest.cs
+++ b/src/Algolia.Search.Test/EndToEnd/Index/SettingsTest.cs
@@ -195,10 +195,10 @@ namespace Algolia.Search.Test.EndToEnd.Index
             settings.NumericAttributesForFiltering = new List<string> { "attribute1", "attribute2" };
 
             var saveSettingsResponseAfterResetNumericAttributesForFiltering = await _index.SetSettingsAsync(settings);
-            saveSettingsResponseAfterChangesNumericAttributesForFiltering.Wait();
+            saveSettingsResponseAfterResetNumericAttributesForFiltering.Wait();
 
             var getSettingsResponseAfterResetNumericAttributesForFiltering = await _index.GetSettingsAsync();
-            Assert.True(TestHelper.AreObjectsEqual(settings, getSettingsResponseAfterResetNumericAttributesForFiltering, specificPropertiesCheck.ToArray()));
+            Assert.AreEqual(new List<string> { "attribute1", "attribute2" }, getSettingsResponseAfterResetNumericAttributesForFiltering.NumericAttributesForFiltering);
 
             // Check specific properties (couldn't be done by test helper)
             Assert.True((string)getSettingsResponseAfterChanges.TypoTolerance == (string)settings.TypoTolerance);

--- a/src/Algolia.Search.Test/Serializer/SerializerTest.cs
+++ b/src/Algolia.Search.Test/Serializer/SerializerTest.cs
@@ -606,6 +606,8 @@ namespace Algolia.Search.Test.Serializer
             Assert.IsNotNull(settings.NumericAttributesForFiltering);
             Assert.True(settings.NumericAttributesForFiltering.Contains("attr1"));
             Assert.True(settings.NumericAttributesForFiltering.Contains("attr2"));
+
+            IndexSettings settingsNumericAttributesisNull = JsonConvert.DeserializeObject<IndexSettings>(json);
         }
 
         [Test]

--- a/src/Algolia.Search.Test/Serializer/SerializerTest.cs
+++ b/src/Algolia.Search.Test/Serializer/SerializerTest.cs
@@ -607,7 +607,9 @@ namespace Algolia.Search.Test.Serializer
             Assert.True(settings.NumericAttributesForFiltering.Contains("attr1"));
             Assert.True(settings.NumericAttributesForFiltering.Contains("attr2"));
 
-            IndexSettings settingsNumericAttributesisNull = JsonConvert.DeserializeObject<IndexSettings>(json);
+            string jsonWithNumericAttributeToIndexNull =
+                "{ \"numericAttributesToIndex\": null}";
+            IndexSettings settingsNumericAttributesisNull = JsonConvert.DeserializeObject<IndexSettings>(jsonWithNumericAttributeToIndexNull);
         }
 
         [Test]

--- a/src/Algolia.Search.Test/Serializer/SerializerTest.cs
+++ b/src/Algolia.Search.Test/Serializer/SerializerTest.cs
@@ -610,6 +610,7 @@ namespace Algolia.Search.Test.Serializer
             string jsonWithNumericAttributeToIndexNull =
                 "{ \"numericAttributesToIndex\": null}";
             IndexSettings settingsNumericAttributesisNull = JsonConvert.DeserializeObject<IndexSettings>(jsonWithNumericAttributeToIndexNull);
+            Assert.AreEqual(null, settingsNumericAttributesisNull.NumericAttributesForFiltering);
         }
 
         [Test]

--- a/src/Algolia.Search/Models/Settings/IndexSettings.cs
+++ b/src/Algolia.Search/Models/Settings/IndexSettings.cs
@@ -281,7 +281,6 @@ namespace Algolia.Search.Models.Settings
         public object RemoveStopWords { get; set; }
 
         // performance
-        [JsonIgnore]
         private bool _numericAttributesForFilteringWasSet = false;
 
         /// <summary>

--- a/src/Algolia.Search/Models/Settings/IndexSettings.cs
+++ b/src/Algolia.Search/Models/Settings/IndexSettings.cs
@@ -311,13 +311,12 @@ namespace Algolia.Search.Models.Settings
         }
 
         // Handling legacy index settings
-        [JsonProperty("numericAttributesToIndex")]
+        [JsonProperty("numericAttributesToIndex", NullValueHandling = NullValueHandling.Include)]
         private List<string> NumericAttributesToIndex
         {
             set
             {
-                if (value != null)
-                { NumericAttributesForFiltering = value; }
+                NumericAttributesForFiltering = value;
             }
         }
 

--- a/src/Algolia.Search/Models/Settings/IndexSettings.cs
+++ b/src/Algolia.Search/Models/Settings/IndexSettings.cs
@@ -286,6 +286,7 @@ namespace Algolia.Search.Models.Settings
 
         /// <summary>
         /// ShouldSerialize predicate from NewtonSoft.json to avoid serializing empty field.
+        /// https://www.newtonsoft.com/json/help/html/ConditionalProperties.htm
         /// </summary>
         public bool ShouldSerializeNumericAttributesForFiltering()
         {

--- a/src/Algolia.Search/Models/Settings/IndexSettings.cs
+++ b/src/Algolia.Search/Models/Settings/IndexSettings.cs
@@ -285,7 +285,7 @@ namespace Algolia.Search.Models.Settings
         private bool _numericAttributesForFilteringWasSet = false;
 
         /// <summary>
-        /// List of numeric attributes that can be used as numerical filters.
+        /// ShouldSerialize predicate from NewtonSoft.json to avoid serializing empty field.
         /// </summary>
         public bool ShouldSerializeNumericAttributesForFiltering()
         {

--- a/src/Algolia.Search/Models/Settings/IndexSettings.cs
+++ b/src/Algolia.Search/Models/Settings/IndexSettings.cs
@@ -282,10 +282,32 @@ namespace Algolia.Search.Models.Settings
 
         // performance
 
+        private bool _numericAttributesForFilteringWasSet = false;
+
         /// <summary>
         /// List of numeric attributes that can be used as numerical filters.
         /// </summary>
-        public List<string> NumericAttributesForFiltering { get; set; }
+        public bool ShouldSerializeNumericAttributesForFiltering()
+        {
+            return _numericAttributesForFilteringWasSet;
+        }
+
+        /// <summary>
+        /// List of numeric attributes that can be used as numerical filters.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Include)]
+        public List<string> NumericAttributesForFiltering
+        {
+            get
+            {
+                return this.NumericAttributesForFiltering;
+            }
+            set
+            {
+                this.NumericAttributesForFiltering = value;
+                _numericAttributesForFilteringWasSet = true;
+            }
+        }
 
         // Handling legacy index settings
         [JsonProperty("numericAttributesToIndex")]

--- a/src/Algolia.Search/Models/Settings/IndexSettings.cs
+++ b/src/Algolia.Search/Models/Settings/IndexSettings.cs
@@ -281,7 +281,7 @@ namespace Algolia.Search.Models.Settings
         public object RemoveStopWords { get; set; }
 
         // performance
-
+        [JsonIgnore]
         private bool _numericAttributesForFilteringWasSet = false;
 
         /// <summary>
@@ -293,6 +293,8 @@ namespace Algolia.Search.Models.Settings
             return _numericAttributesForFilteringWasSet;
         }
 
+        private List<string> _numericAttributesForFiltering;
+
         /// <summary>
         /// List of numeric attributes that can be used as numerical filters.
         /// </summary>
@@ -301,11 +303,11 @@ namespace Algolia.Search.Models.Settings
         {
             get
             {
-                return this.NumericAttributesForFiltering;
+                return _numericAttributesForFiltering;
             }
             set
             {
-                this.NumericAttributesForFiltering = value;
+                _numericAttributesForFiltering = value;
                 _numericAttributesForFilteringWasSet = true;
             }
         }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | 
| Need Doc update   | no


## Describe your change
- Include null for NewtonSoft on `NumericAttributesForFiltering` parameter.
- Add the method [ShouldSerialize](https://www.newtonsoft.com/json/help/html/P_Newtonsoft_Json_Serialization_JsonProperty_ShouldSerialize.htm) from newtonsoft to avoid serialize empty field.
- Add a dedicated setter for `NumericAttributesForFiltering`. 
- Add tests with `null` for `NumericAttributesForFiltering`


## What problem is this fixing?

Our C# client is using newtonsoft.json to serialize our parameter. This serializer is configurable and for the C# client we exclude null field in our request. However for a specific attribute on settings `NumericAttributesForFiltering` we need to send null to the API. 

