### PR TITLE
fix: ab test nullability keys

### DIFF
--- a/src/Algolia.Search.Test/EndToEnd/Analytics/AnalyticsAATest.cs
+++ b/src/Algolia.Search.Test/EndToEnd/Analytics/AnalyticsAATest.cs
@@ -84,12 +84,12 @@ namespace Algolia.Search.Test.EndToEnd.Analytics
             abTest.AbTestId = addAbTest.ABTestId;
             _index.WaitTask(addAbTest.TaskID);
 
-            ABTest abTestToCheck = await BaseTest.AnalyticsClient.GetABTestAsync(abTest.AbTestId.Value);
+            ABTest abTestToCheck = await BaseTest.AnalyticsClient.GetABTestAsync(abTest.AbTestId);
             Assert.IsTrue(TestHelper.AreObjectsEqual(abTestToCheck, abTest, "CreatedAt", "Status", "ClickCount",
                 "ConversionCount"));
             Assert.That(abTestToCheck.Status, Is.EqualTo("active"));
 
-            var deleteAbTest = await BaseTest.AnalyticsClient.DeleteABTestAsync(abTest.AbTestId.Value);
+            var deleteAbTest = await BaseTest.AnalyticsClient.DeleteABTestAsync(abTest.AbTestId);
             _index.WaitTask(deleteAbTest.TaskID);
         }
 

--- a/src/Algolia.Search.Test/EndToEnd/Analytics/AnalyticsAATest.cs
+++ b/src/Algolia.Search.Test/EndToEnd/Analytics/AnalyticsAATest.cs
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2018 Algolia
+* Copyright (c) 2018-2021 Algolia
 * http://www.algolia.com/
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -63,7 +63,7 @@ namespace Algolia.Search.Test.EndToEnd.Analytics
 
             addOne.Wait();
 
-            var abTest = new ABTest
+            var abTest = new AddABTestRequest
             {
                 Name = testName,
                 Variants = new List<Variant>
@@ -81,15 +81,16 @@ namespace Algolia.Search.Test.EndToEnd.Analytics
             };
 
             AddABTestResponse addAbTest = await BaseTest.AnalyticsClient.AddABTestAsync(abTest);
-            abTest.AbTestId = addAbTest.ABTestId;
             _index.WaitTask(addAbTest.TaskID);
 
-            ABTest abTestToCheck = await BaseTest.AnalyticsClient.GetABTestAsync(abTest.AbTestId);
-            Assert.IsTrue(TestHelper.AreObjectsEqual(abTestToCheck, abTest, "CreatedAt", "Status", "ClickCount",
-                "ConversionCount"));
+            ABTest abTestToCheck = await BaseTest.AnalyticsClient.GetABTestAsync(addAbTest.ABTestId);
+            Assert.AreEqual(abTest.Name, abTestToCheck.Name);
+            Assert.IsTrue(TestHelper.AreObjectsEqual(abTest.Variants.ElementAt(0), abTestToCheck.Variants.ElementAt(0), "ClickCount", "ConversionCount"));
+            Assert.IsTrue(TestHelper.AreObjectsEqual(abTest.Variants.ElementAt(1), abTestToCheck.Variants.ElementAt(1), "ClickCount", "ConversionCount"));
+            Assert.AreEqual(abTest.EndAt, abTestToCheck.EndAt);
             Assert.That(abTestToCheck.Status, Is.EqualTo("active"));
 
-            var deleteAbTest = await BaseTest.AnalyticsClient.DeleteABTestAsync(abTest.AbTestId);
+            var deleteAbTest = await BaseTest.AnalyticsClient.DeleteABTestAsync(addAbTest.ABTestId);
             _index.WaitTask(deleteAbTest.TaskID);
         }
 

--- a/src/Algolia.Search.Test/EndToEnd/Analytics/AnalyticsAbTest.cs
+++ b/src/Algolia.Search.Test/EndToEnd/Analytics/AnalyticsAbTest.cs
@@ -84,7 +84,7 @@ namespace Algolia.Search.Test.EndToEnd.Analytics
             abTest.AbTestId = addAbTest.ABTestId;
             _index1.WaitTask(addAbTest.TaskID);
 
-            ABTest abTestToCheck = await BaseTest.AnalyticsClient.GetABTestAsync(abTest.AbTestId.Value);
+            ABTest abTestToCheck = await BaseTest.AnalyticsClient.GetABTestAsync(abTest.AbTestId);
             Assert.IsTrue(TestHelper.AreObjectsEqual(abTestToCheck, abTest, "CreatedAt", "Status", "ClickCount",
                 "ConversionCount", "TrackedSearchCount"));
             Assert.That(abTestToCheck.Status, Is.EqualTo("active"));
@@ -95,17 +95,17 @@ namespace Algolia.Search.Test.EndToEnd.Analytics
                 listAbTests.ABTests.FirstOrDefault(x => x.AbTestId == abTest.AbTestId), abTest, "CreatedAt", "Status",
                 "ClickCount", "ConversionCount", "TrackedSearchCount"));
 
-            await BaseTest.AnalyticsClient.StopABTestAsync(abTest.AbTestId.Value);
+            await BaseTest.AnalyticsClient.StopABTestAsync(abTest.AbTestId);
 
-            ABTest stoppedAbTest = await BaseTest.AnalyticsClient.GetABTestAsync(abTest.AbTestId.Value);
+            ABTest stoppedAbTest = await BaseTest.AnalyticsClient.GetABTestAsync(abTest.AbTestId);
             Assert.That(stoppedAbTest.Status, Is.EqualTo("stopped"));
 
-            DeleteABTestResponse deleteAbTest = await BaseTest.AnalyticsClient.DeleteABTestAsync(abTest.AbTestId.Value);
+            DeleteABTestResponse deleteAbTest = await BaseTest.AnalyticsClient.DeleteABTestAsync(abTest.AbTestId);
             _index1.WaitTask(deleteAbTest.TaskID);
 
             AlgoliaApiException ex =
                 Assert.ThrowsAsync<AlgoliaApiException>(() =>
-                    BaseTest.AnalyticsClient.GetABTestAsync(abTest.AbTestId.Value));
+                    BaseTest.AnalyticsClient.GetABTestAsync(abTest.AbTestId));
             Assert.That(ex.HttpErrorCode, Is.EqualTo(404));
         }
 

--- a/src/Algolia.Search.Test/EndToEnd/Analytics/AnalyticsAbTest.cs
+++ b/src/Algolia.Search.Test/EndToEnd/Analytics/AnalyticsAbTest.cs
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2018 Algolia
+* Copyright (c) 2018-2021 Algolia
 * http://www.algolia.com/
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -66,7 +66,7 @@ namespace Algolia.Search.Test.EndToEnd.Analytics
             DateTime tomorrow = new DateTime(utcNow.Year, utcNow.Month, utcNow.Day, utcNow.Hour, utcNow.Minute, 0,
                 utcNow.Kind);
 
-            var abTest = new ABTest
+            var abTest = new AddABTestRequest
             {
                 Name = testName,
                 Variants = new List<Variant>
@@ -81,31 +81,38 @@ namespace Algolia.Search.Test.EndToEnd.Analytics
             addTwo.Wait();
 
             AddABTestResponse addAbTest = await BaseTest.AnalyticsClient.AddABTestAsync(abTest);
-            abTest.AbTestId = addAbTest.ABTestId;
             _index1.WaitTask(addAbTest.TaskID);
 
-            ABTest abTestToCheck = await BaseTest.AnalyticsClient.GetABTestAsync(abTest.AbTestId);
-            Assert.IsTrue(TestHelper.AreObjectsEqual(abTestToCheck, abTest, "CreatedAt", "Status", "ClickCount",
-                "ConversionCount", "TrackedSearchCount"));
+            ABTest abTestToCheck = await BaseTest.AnalyticsClient.GetABTestAsync(addAbTest.ABTestId);
+            Assert.AreEqual(abTest.Name, abTestToCheck.Name);
+            Assert.IsTrue(TestHelper.AreObjectsEqual(abTest.Variants.ElementAt(0), abTestToCheck.Variants.ElementAt(0), "ClickCount", "ConversionCount"));
+            Assert.IsTrue(TestHelper.AreObjectsEqual(abTest.Variants.ElementAt(1), abTestToCheck.Variants.ElementAt(1), "ClickCount", "ConversionCount"));
+            Assert.AreEqual(abTest.EndAt, abTestToCheck.EndAt);
             Assert.That(abTestToCheck.Status, Is.EqualTo("active"));
 
             ABTestsResponse listAbTests = await BaseTest.AnalyticsClient.GetABTestsAsync();
-            Assert.IsTrue(listAbTests.ABTests.Any(x => x.AbTestId == abTest.AbTestId));
+            Assert.IsTrue(listAbTests.ABTests.Any(x => x.AbTestId == addAbTest.ABTestId));
+            ABTest abTestFromList = listAbTests.ABTests.FirstOrDefault(x => x.AbTestId == addAbTest.ABTestId);
+            Assert.AreEqual(abTestFromList.Name, abTestToCheck.Name);
             Assert.IsTrue(TestHelper.AreObjectsEqual(
-                listAbTests.ABTests.FirstOrDefault(x => x.AbTestId == abTest.AbTestId), abTest, "CreatedAt", "Status",
-                "ClickCount", "ConversionCount", "TrackedSearchCount"));
+                abTestFromList.Variants.ElementAt(0), abTest.Variants.ElementAt(0),
+                "ClickCount", "ConversionCount"));
+            Assert.IsTrue(TestHelper.AreObjectsEqual(
+                abTestFromList.Variants.ElementAt(1), abTest.Variants.ElementAt(1),
+                "ClickCount", "ConversionCount"));
+            Assert.AreEqual(abTestFromList.EndAt, abTestToCheck.EndAt);
 
-            await BaseTest.AnalyticsClient.StopABTestAsync(abTest.AbTestId);
+            await BaseTest.AnalyticsClient.StopABTestAsync(addAbTest.ABTestId);
 
-            ABTest stoppedAbTest = await BaseTest.AnalyticsClient.GetABTestAsync(abTest.AbTestId);
+            ABTest stoppedAbTest = await BaseTest.AnalyticsClient.GetABTestAsync(addAbTest.ABTestId);
             Assert.That(stoppedAbTest.Status, Is.EqualTo("stopped"));
 
-            DeleteABTestResponse deleteAbTest = await BaseTest.AnalyticsClient.DeleteABTestAsync(abTest.AbTestId);
+            DeleteABTestResponse deleteAbTest = await BaseTest.AnalyticsClient.DeleteABTestAsync(addAbTest.ABTestId);
             _index1.WaitTask(deleteAbTest.TaskID);
 
             AlgoliaApiException ex =
                 Assert.ThrowsAsync<AlgoliaApiException>(() =>
-                    BaseTest.AnalyticsClient.GetABTestAsync(abTest.AbTestId));
+                    BaseTest.AnalyticsClient.GetABTestAsync(addAbTest.ABTestId));
             Assert.That(ex.HttpErrorCode, Is.EqualTo(404));
         }
 

--- a/src/Algolia.Search/Clients/AnalyticsClient.cs
+++ b/src/Algolia.Search/Clients/AnalyticsClient.cs
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2018 Algolia
+* Copyright (c) 2018-2021 Algolia
 * http://www.algolia.com/
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -133,6 +133,19 @@ namespace Algolia.Search.Clients
         {
             return await _transport.ExecuteRequestAsync<AddABTestResponse, ABTest>(HttpMethod.Post,
                     "/2/abtests", CallType.Write, aBTest, requestOptions, ct)
+                .ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public AddABTestResponse AddABTest(AddABTestRequest aBTestRequest, RequestOptions requestOptions = null) =>
+            AsyncHelper.RunSync(() => AddABTestAsync(aBTestRequest, requestOptions));
+
+        /// <inheritdoc />
+        public async Task<AddABTestResponse> AddABTestAsync(AddABTestRequest aBTestRequest, RequestOptions requestOptions = null,
+            CancellationToken ct = default)
+        {
+            return await _transport.ExecuteRequestAsync<AddABTestResponse, AddABTestRequest>(HttpMethod.Post,
+                    "/2/abtests", CallType.Write, aBTestRequest, requestOptions, ct)
                 .ConfigureAwait(false);
         }
 

--- a/src/Algolia.Search/Clients/IAnalyticsClient.cs
+++ b/src/Algolia.Search/Clients/IAnalyticsClient.cs
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2018 Algolia
+* Copyright (c) 2021 Algolia
 * http://www.algolia.com/
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -21,6 +21,7 @@
 * THE SOFTWARE.
 */
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Algolia.Search.Http;
@@ -77,6 +78,7 @@ namespace Algolia.Search.Clients
         /// <param name="aBTest"></param>
         /// <param name="requestOptions">Add extra http header or query parameters to Algolia</param>
         /// <returns></returns>
+        [Obsolete("Deprecated, use the version with an AddABTestRequest parameter instead.")]
         AddABTestResponse AddABTest(ABTest aBTest, RequestOptions requestOptions = null);
 
         /// <summary>
@@ -86,7 +88,26 @@ namespace Algolia.Search.Clients
         /// <param name="requestOptions">Add extra http header or query parameters to Algolia</param>
         /// <param name="ct">Optional cancellation token</param>
         /// <returns></returns>
+        [Obsolete("Deprecated, use the version with an AddABTestRequest parameter instead.")]
         Task<AddABTestResponse> AddABTestAsync(ABTest aBTest, RequestOptions requestOptions = null,
+            CancellationToken ct = default);
+
+        /// <summary>
+        /// Creates a new AB Test with the provided configuration.
+        /// </summary>
+        /// <param name="aBTestRequest"></param>
+        /// <param name="requestOptions">Add extra http header or query parameters to Algolia</param>
+        /// <returns></returns>
+        AddABTestResponse AddABTest(AddABTestRequest aBTestRequest, RequestOptions requestOptions = null);
+
+        /// <summary>
+        /// Creates a new AB Test with the provided configuration.
+        /// </summary>
+        /// <param name="aBTestRequest"></param>
+        /// <param name="requestOptions">Add extra http header or query parameters to Algolia</param>
+        /// <param name="ct">Optional cancellation token</param>
+        /// <returns></returns>
+        Task<AddABTestResponse> AddABTestAsync(AddABTestRequest aBTestRequest, RequestOptions requestOptions = null,
             CancellationToken ct = default);
 
         /// <summary>

--- a/src/Algolia.Search/Models/Analytics/ABTest.cs
+++ b/src/Algolia.Search/Models/Analytics/ABTest.cs
@@ -50,18 +50,18 @@ namespace Algolia.Search.Models.Analytics
         /// <summary>
         /// End date for the AB Test
         /// </summary>
-        public DateTime? EndAt { get; set; }
+        public DateTime EndAt { get; set; }
 
         /// <summary>
         /// Date of creation
         /// </summary>
-        public DateTime? CreatedAt { get; set; }
+        public DateTime CreatedAt { get; set; }
 
         /// <summary>
         /// Ab test ID
         /// </summary>
         [JsonProperty(PropertyName = "abTestID")]
-        public long? AbTestId { get; set; }
+        public long AbTestId { get; set; }
 
         /// <summary>
         /// ABTest significance based on click data. Should be > 0.95 to be considered significant (no matter which variant is winning).

--- a/src/Algolia.Search/Models/Analytics/AddABTestRequest.cs
+++ b/src/Algolia.Search/Models/Analytics/AddABTestRequest.cs
@@ -1,0 +1,49 @@
+/*
+* Copyright (c) 2021 Algolia
+* http://www.algolia.com/
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+
+using System;
+using System.Collections.Generic;
+
+namespace Algolia.Search.Models.Analytics
+{
+    /// <summary>
+    /// https://www.algolia.com/doc/rest-api/ab-test/#add-ab-test
+    /// </summary>
+    public class AddABTestRequest
+    {
+        /// <summary>
+        /// AB Test name.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// List of variants for the ab test
+        /// </summary>
+        public IEnumerable<Variant> Variants { get; set; }
+
+        /// <summary>
+        /// End date for the AB Test
+        /// </summary>
+        public DateTime EndAt { get; set; }
+    }
+}

--- a/src/Algolia.Search/Models/Analytics/Variant.cs
+++ b/src/Algolia.Search/Models/Analytics/Variant.cs
@@ -38,7 +38,7 @@ namespace Algolia.Search.Models.Analytics
         /// <summary>
         /// Percentage of the traffic that should be going to the variant. The sum of the percentage should be equal to 100.
         /// </summary>
-        public int? TrafficPercentage { get; set; }
+        public int TrafficPercentage { get; set; }
 
         /// <summary>
         /// Description of the variant. This is useful when seing the results in the dashboard or via the API.


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | Fix # [here](https://github.com/algolia/algoliasearch-client-specs-internal/issues/146)
| Need Doc update   | no


## Describe your change

- Update key which aren't nullable
- New `AddABTestRequest` which exposes only the needed properties to send when creating an ABTest

## What problem is this fixing?

Some properties have been marked as nullable to not been sent in the request, but are always present in the response. To improve DX, let's separate the request from the actual `ABTest` object.