### PR TITLE
Stub out classes for querying the recommend client 

### DIFF
--- a/src/Algolia.Search.Test/BaseTest.cs
+++ b/src/Algolia.Search.Test/BaseTest.cs
@@ -40,6 +40,7 @@ public class BaseTest
     internal static AnalyticsClient AnalyticsClient;
     internal static RecommendationClient RecommendationClient;
     internal static DictionaryClient DictionaryClient;
+    internal static RecommendClient RecommendClient;
 
     [OneTimeSetUp]
     public void Setup()
@@ -55,5 +56,6 @@ public class BaseTest
         AnalyticsClient = new AnalyticsClient(TestHelper.ApplicationId1, TestHelper.AdminKey1);
         RecommendationClient = new RecommendationClient(TestHelper.ApplicationId1, TestHelper.AdminKey1, "eu");
         DictionaryClient = new DictionaryClient(TestHelper.ApplicationId1, TestHelper.AdminKey1);
+        RecommendClient = new RecommendClient(TestHelper.ApplicationId1, TestHelper.AdminKey1);
     }
 }

--- a/src/Algolia.Search.Test/EndToEnd/Index/RecommendTest.cs
+++ b/src/Algolia.Search.Test/EndToEnd/Index/RecommendTest.cs
@@ -1,0 +1,127 @@
+/*
+* Copyright (c) 2018 Algolia
+* http://www.algolia.com/
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Algolia.Search.Clients;
+using Algolia.Search.Models.Common;
+using Algolia.Search.Models.Recommend;
+using Algolia.Search.Models.Search;
+using Algolia.Search.Models.Settings;
+using Algolia.Search.Utils;
+using NUnit.Framework;
+
+namespace Algolia.Search.Test.EndToEnd.Index
+{
+    [TestFixture]
+    [Parallelizable]
+    public class RecommendTest
+    {
+        private string _indexName;
+        private SearchIndex _index;
+        private IEnumerable<Product> _employees;
+
+        [OneTimeSetUp]
+        public void Init()
+        {
+            _indexName = TestHelper.GetTestIndexName("recommend");
+            _index = BaseTest.SearchClient.InitIndex(_indexName);
+            _employees = InitEmployees();
+        }
+
+        //fixme: stubbed
+        [Test]
+        public async Task RecommendTestAsync()
+        {
+            BatchIndexingResponse addObjectResponse =
+                await _index.SaveObjectsAsync(_employees, autoGenerateObjectId: true);
+            addObjectResponse.Wait();
+
+            Assert.IsInstanceOf<BatchIndexingResponse>(addObjectResponse);
+            Assert.NotNull(addObjectResponse);
+
+            IndexSettings settings = new IndexSettings
+            {
+                AttributesForFaceting = new List<string> { "searchable(name)" },
+                //todo: enable recommendations on this app/index, configure reco model
+
+            };
+            var setSettingsResponse = await _index.SetSettingsAsync(settings);
+            setSettingsResponse.Wait();
+
+            Assert.IsInstanceOf<SetSettingsResponse>(setSettingsResponse);
+            Assert.NotNull(setSettingsResponse);
+
+            var objectIdToRecommendOn = "3";
+
+            var objectIdToPromote1 = "1";
+            var objectIdToPromote2 = "2";
+            //todo: feed 1 and 2 to recommendation engine
+
+
+            var recos = await BaseTest.RecommendClient.GetRecommendationsAsync(new RecommendRequestItem
+            {
+                IndexName = _indexName,
+                ObjectID = objectIdToRecommendOn,
+                MaxRecommendations = 3,
+                Model = "related-products",
+            });
+
+            var recommendedIds = recos.Items.First().Hits.Select(x => x.ObjectID);
+            Assert.That(recommendedIds, Contains.Item(objectIdToPromote1));
+            Assert.That(recommendedIds, Contains.Item(objectIdToPromote2));
+
+            //todo: perform a request with multiple objects and multiple results 
+        }
+
+        private IEnumerable<Product> InitEmployees()
+        {
+            var objectId = 1;
+            return new List<Product>()
+            {
+                new Product { Manufacturer = "Algolia",         ObjectID = objectId++.ToString(), Name="iPhone 1" },
+                new Product { Manufacturer = "Algolia",         ObjectID = objectId++.ToString(), Name="iPhone 2" },
+                new Product { Manufacturer = "Amazon",          ObjectID = objectId++.ToString(), Name="iPhone 3" },
+                new Product { Manufacturer = "Apple",           ObjectID = objectId++.ToString(), Name="iPhone 4" },
+                new Product { Manufacturer = "Apple",           ObjectID = objectId++.ToString(), Name="iPhone 5" },
+                new Product { Manufacturer = "Arista Networks", ObjectID = objectId++.ToString(), Name="iPhone 6" },
+                new Product { Manufacturer = "Google",          ObjectID = objectId++.ToString(), Name="iPhone 7" },
+                new Product { Manufacturer = "Google",          ObjectID = objectId++.ToString(), Name="iPhone 8" },
+                new Product { Manufacturer = "Google",          ObjectID = objectId++.ToString(), Name="iPhone 9" },
+                new Product { Manufacturer = "SpaceX",          ObjectID = objectId++.ToString(), Name="iPhone X" },
+                new Product { Manufacturer = "SpaceX",          ObjectID = objectId++.ToString(), Name="iPhone X2" },
+                new Product { Manufacturer = "SpaceX",          ObjectID = objectId++.ToString(), Name="iPhone X3 The Last Stand" },
+                new Product { Manufacturer = "Yahoo",           ObjectID = objectId++.ToString(), Name="iPhone -1: The Foretold one" },
+            };
+        }
+
+        public class Product
+        {
+            public string ObjectID { get; set; }
+            public string Manufacturer { get; set; }
+            public string Name { get; set; }
+            public string QueryID { get; set; }
+        }
+    }
+}

--- a/src/Algolia.Search/Clients/IRecommendClient.cs
+++ b/src/Algolia.Search/Clients/IRecommendClient.cs
@@ -1,0 +1,68 @@
+/*
+* Copyright (c) 2018 Algolia
+* http://www.algolia.com/
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Algolia.Search.Http;
+using Algolia.Search.Models.Recommend;
+
+namespace Algolia.Search.Clients
+{
+
+    /// <summary>
+    /// Recommend Client interface
+    /// </summary>
+    public interface IRecommendClient
+    {
+        /// <summary>
+        /// Get recommendations for given object
+        /// </summary>
+        /// <param name="requests">Object ID and index pairs to retreive recommendations for</param>
+        /// <param name="requestOptions">Add extra http header or query parameters to Algolia</param>
+        RecommendResponse GetRecommendations(RecommendRequestItem requests, RequestOptions requestOptions = null);
+
+        /// <summary>
+        /// Get recommendations for given objects
+        /// </summary>
+        /// <param name="requests">Object ID and index pairs to retreive recommendations for</param>
+        /// <param name="requestOptions">Add extra http header or query parameters to Algolia</param>
+        RecommendResponse GetRecommendations(IEnumerable<RecommendRequestItem> requests, RequestOptions requestOptions = null);
+
+        /// <summary>
+        /// Get recommendations for given object
+        /// </summary>
+        /// <param name="requests">Object ID and index pairs to retreive recommendations for</param>
+        /// <param name="requestOptions">Add extra http header or query parameters to Algolia</param>
+        /// <param name="ct">Task CancellationToken</param>
+        Task<RecommendResponse> GetRecommendationsAsync(RecommendRequestItem requests, RequestOptions requestOptions = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Get recommendations for given objects
+        /// </summary>
+        /// <param name="requests">Object ID and index pairs to retreive recommendations for</param>
+        /// <param name="requestOptions">Add extra http header or query parameters to Algolia</param>
+        /// <param name="ct">Task CancellationToken</param>
+        Task<RecommendResponse> GetRecommendationsAsync(IEnumerable<RecommendRequestItem> requests, RequestOptions requestOptions = null, CancellationToken ct = default);
+    }
+}

--- a/src/Algolia.Search/Clients/RecommendClient.cs
+++ b/src/Algolia.Search/Clients/RecommendClient.cs
@@ -1,0 +1,131 @@
+/*
+* Copyright (c) 2018 Algolia
+* http://www.algolia.com/
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Algolia.Search.Http;
+using Algolia.Search.Models.Enums;
+using Algolia.Search.Models.Recommend;
+using Algolia.Search.Transport;
+using Algolia.Search.Utils;
+
+namespace Algolia.Search.Clients
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class RecommendClient : IRecommendClient
+    {
+        private readonly HttpTransport _transport;
+
+        /// <summary>
+        /// Create a new recommend client for the given appID
+        /// </summary>
+        /// <param name="applicationId">Your application ID</param>
+        /// <param name="apiKey">Your Api KEY</param>
+        public RecommendClient(string applicationId, string apiKey) : this(
+            new SearchConfig(applicationId, apiKey), new AlgoliaHttpRequester())
+        {
+        }
+
+        /// <summary>
+        /// Initialize a client with custom config
+        /// </summary>
+        /// <param name="config">Algolia config instance</param>
+        public RecommendClient(SearchConfig config) : this(config, new AlgoliaHttpRequester())
+        {
+        }
+
+        /// <summary>
+        /// Initialize the client with custom config and custom Requester
+        /// </summary>
+        /// <param name="config">Algolia config instance</param>
+        /// <param name="httpRequester">Your Http requester implementation of <see cref="IHttpRequester"/></param>
+        public RecommendClient(SearchConfig config, IHttpRequester httpRequester)
+        {
+            if (httpRequester == null)
+            {
+                throw new ArgumentNullException(nameof(httpRequester), "An httpRequester is required");
+            }
+
+            if (config == null)
+            {
+                throw new ArgumentNullException(nameof(config), "A config is required");
+            }
+
+            if (string.IsNullOrWhiteSpace(config.AppId))
+            {
+                throw new ArgumentNullException(nameof(config.AppId), "Application ID is required");
+            }
+
+            if (string.IsNullOrWhiteSpace(config.ApiKey))
+            {
+                throw new ArgumentNullException(nameof(config.ApiKey), "An API key is required");
+            }
+
+            _transport = new HttpTransport(config, httpRequester);
+        }
+
+        /// <inheritdoc />
+        public RecommendResponse GetRecommendations(RecommendRequestItem request,
+            RequestOptions requestOptions = null) =>
+            AsyncHelper.RunSync(() => GetRecommendationsAsync(new[] { request }, requestOptions));
+
+        /// <inheritdoc />
+        public RecommendResponse GetRecommendations(IEnumerable<RecommendRequestItem> requests,
+            RequestOptions requestOptions = null) =>
+            AsyncHelper.RunSync(() => GetRecommendationsAsync(requests, requestOptions));
+
+        /// <inheritdoc />
+        public Task<RecommendResponse> GetRecommendationsAsync(
+            RecommendRequestItem request, RequestOptions requestOptions = null,
+            CancellationToken ct = default) => GetRecommendationsAsync(new[] { request }, requestOptions);
+
+        /// <inheritdoc />
+        public async Task<RecommendResponse> GetRecommendationsAsync(
+            IEnumerable<RecommendRequestItem> requests, RequestOptions requestOptions = null,
+            CancellationToken ct = default) 
+        {
+            if (requests == null)
+            {
+                throw new ArgumentNullException(nameof(requests));
+            }
+
+            var req = new RecommendRequest
+            {
+                Requests = requests.ToList()
+            };
+
+            RecommendResponse resp = await _transport
+                .ExecuteRequestAsync<RecommendResponse, RecommendRequest>(
+                    HttpMethod.Post, "/1/indexes/*/recommendations", CallType.Write, req, requestOptions, ct)
+                .ConfigureAwait(false);
+
+            return resp;
+        }
+    }
+}

--- a/src/Algolia.Search/Models/Recommend/RecommendRequest.cs
+++ b/src/Algolia.Search/Models/Recommend/RecommendRequest.cs
@@ -1,0 +1,38 @@
+/*
+* Copyright (c) 2018 Algolia
+* http://www.algolia.com/
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+using System.Collections.Generic;
+
+namespace Algolia.Search.Models.Recommend
+{
+
+    /// <summary>
+    /// Request for recommend api
+    /// </summary>
+    public class RecommendRequest
+    {
+        /// <summary>
+        /// All the requests to get recommendations for
+        /// </summary>
+        public List<RecommendRequestItem> Requests { get; set; }
+    }
+}

--- a/src/Algolia.Search/Models/Recommend/RecommendRequestItem.cs
+++ b/src/Algolia.Search/Models/Recommend/RecommendRequestItem.cs
@@ -1,0 +1,69 @@
+/*
+* Copyright (c) 2018 Algolia
+* http://www.algolia.com/
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+using System.Collections.Generic;
+
+namespace Algolia.Search.Models.Recommend
+{
+    /// <summary>
+    /// Single item for <see cref="RecommendRequest"/>
+    /// </summary>
+    public class RecommendRequestItem
+
+    {
+        /// <summary>
+        /// Required. Name of the index to target.
+        /// </summary>
+        public string IndexName { get; set; }
+
+        //todo: convert to enum
+        /// <summary>
+        /// Required. The recommendation model to use, either "related-products" or "bought-together"
+        /// </summary>
+        public string Model { get; set; }
+
+        /// <summary>
+        /// Required. The objectID to get recommendations for.
+        /// </summary>
+        public string ObjectID { get; set; }
+
+        /// <summary>
+        /// Optional. The threshold to use when filtering recommendations by their score.
+        /// </summary>
+        public long Threshold { get; set; } = 0;
+
+        /// <summary>
+        /// Optional. The maximum number of recommendations to retrieve.
+        /// </summary>
+        public long MaxRecommendations { get; set; } = 3;
+
+        /// <summary>
+        /// Optional. A key-value mapping of search parameters to filter the recommendations.
+        /// </summary>
+        public Dictionary<string, string> QueryParameters { get; set; }
+
+        /// <summary>
+        /// Optional. A key-value mapping of search parameters to use as fallback when there are no recommendations.
+        /// </summary>
+        public Dictionary<string, string> FallbackParameters { get; set; }
+    }
+}

--- a/src/Algolia.Search/Models/Recommend/RecommendResponse.cs
+++ b/src/Algolia.Search/Models/Recommend/RecommendResponse.cs
@@ -1,0 +1,37 @@
+/*
+* Copyright (c) 2018 Algolia
+* http://www.algolia.com/
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+using System.Collections.Generic;
+
+namespace Algolia.Search.Models.Recommend
+{
+    /// <summary>
+    /// Response from Recommend api
+    /// </summary>
+    public class RecommendResponse
+    {
+        /// <summary>
+        /// Recommendations for all requests
+        /// </summary>
+        public List<RecommendResponseItem> Items { get; set; }
+    }
+}

--- a/src/Algolia.Search/Models/Recommend/RecommendResponseItem.cs
+++ b/src/Algolia.Search/Models/Recommend/RecommendResponseItem.cs
@@ -1,0 +1,49 @@
+/*
+* Copyright (c) 2018 Algolia
+* http://www.algolia.com/
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Algolia.Search.Models.Recommend
+{
+    /// <summary>
+    /// Single response item for recommend api
+    /// </summary>
+    public class RecommendResponseItem
+    {
+        /// <summary>
+        /// Recommendations
+        /// </summary>
+        public List<RecommendSearchResult> Hits { get; set; }
+
+        /// <summary>
+        /// QueryID reference
+        /// </summary>
+        [JsonProperty(PropertyName = "queryID")]
+        public string QueryID { get; set; }
+
+        /// <summary>
+        /// Number of hits matched by the query.
+        /// </summary>
+        public int NbHits { get; set; }
+    }
+}

--- a/src/Algolia.Search/Models/Recommend/RecommendSearchResult.cs
+++ b/src/Algolia.Search/Models/Recommend/RecommendSearchResult.cs
@@ -1,0 +1,40 @@
+/*
+* Copyright (c) 2018 Algolia
+* http://www.algolia.com/
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+namespace Algolia.Search.Models.Recommend
+{
+    /// <summary>
+    /// Recommended item based on request
+    /// </summary>
+    public class RecommendSearchResult
+    {
+        /// <summary>
+        /// Recommended item based on input and model
+        /// </summary>
+        public string ObjectID { get; set; }
+
+        /// <summary>
+        /// Score of the object based on the model
+        /// </summary>
+        public double Score { get; set; }
+    }
+}


### PR DESCRIPTION

| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | Fix #...  <!-- will close issue automatically, if any -->
| Need Doc update   | yes


## Describe your change

<!-- 
    Please describe your change, add as much detail as 
    necessary to understand your code.
-->
Add Recommend client for this api https://www.algolia.com/doc/rest-api/recommend/ This code is thus far untested, I just wanted to facilitate the team in bringing this to life by stubbing out basic code. I wrote a test, but I don't know enough about how the recommend models work to know if it is logically sound. I also think that recommend is gated behind a paywall so not sure if the test indexes we set up via tests would have that option enabled for this test to work. Or if it would need some time to process in order for it to run successfully to validate that recommendations are working. Perhaps that test index has some pre-seeded data we could use to validate this instead.

## What problem is this fixing?

<!-- 
    Please include everything needed to understand the problem, 
    its context and consequences, and, if possible, how to recreate it.
-->
Recommend api currently only has JS support. My company would like to be able to get these from C# code.
