### PR TITLE
test: Update Personalization region

### DIFF
--- a/src/Algolia.Search.Test/BaseTest.cs
+++ b/src/Algolia.Search.Test/BaseTest.cs
@@ -48,7 +48,7 @@ public class BaseTest
         SearchClient2 = new SearchClient(configClient2);
         McmClient = new SearchClient(TestHelper.McmApplicationId, TestHelper.McmAdminKey);
         AnalyticsClient = new AnalyticsClient(TestHelper.ApplicationId1, TestHelper.AdminKey1);
-        PersonalizationClient = new PersonalizationClient(TestHelper.ApplicationId1, TestHelper.AdminKey1, "eu");
+        PersonalizationClient = new PersonalizationClient(TestHelper.ApplicationId1, TestHelper.AdminKey1, "us");
         DictionaryClient = new DictionaryClient(TestHelper.ApplicationId1, TestHelper.AdminKey1);
     }
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no     
| Need Doc update   | no


## Describe your change

Update region to `us` for the Personalization tests.

## What problem is this fixing?

When wanting to release the new Recommend client, Personalization tests started to suddenly fail with:
`PersonalizationClient.SetPersonalizationStrategy failure: HttpErrorCode: 401, HttpMessage {"status":401,"message":"The log processing region does not match"}`

After checking the Analytics region of our test app, it turns out that it's indeed `us`.
My guess is that the problem started because the test was previously ignored due to the [SetPersonalizationStrategy quota](https://github.com/algolia/algoliasearch-client-csharp/blob/master/src/Algolia.Search.Test/EndToEnd/Personalization/PersonalizationClientTest.cs#L55) that was probably reached by other clients, and it suddenly got reset.

## Note

No idea why the test keeps being skipped on branches and fails on master 🤷 :
```
Skipped TestPersonalizationClient [1 s]
Passed!  - Failed:     0, Passed:    84, Skipped:     2, Total:    86, Duration: 1 m 38 s
```