### PR TITLE
fix: StackOverflow in MCM test

### DIFF
--- a/src/Algolia.Search.Test/EndToEnd/Index/MultiClusterManagementTest.cs
+++ b/src/Algolia.Search.Test/EndToEnd/Index/MultiClusterManagementTest.cs
@@ -95,30 +95,38 @@ namespace Algolia.Search.Test.EndToEnd.Index
 
         private void WaitUserId(string userId)
         {
-            try
+            bool found = false;
+            // Loop until we have found the userID
+            do
             {
-                BaseTest.McmClient.GetUserId(userId);
-            }
-            catch (AlgoliaApiException)
-            {
-                Task.Delay(1000);
-                // Loop until we have found the userID
-                WaitUserId(userId);
-            }
+                try
+                {
+                    BaseTest.McmClient.GetUserId(userId);
+                    found = true;
+                }
+                catch (AlgoliaApiException)
+                {
+                    Task.Delay(1000).Wait();
+                }
+            } while (!found);
         }
 
         private void RemoveUserId(string userId)
         {
-            try
+            bool removed = false;
+            // Loop until we don't have Error 400: "Another mapping operation is already running for this userID"
+            do
             {
-                BaseTest.McmClient.RemoveUserId(userId);
-            }
-            catch (AlgoliaApiException)
-            {
-                // Loop until we don't have Error 400: "Another mapping operation is already running for this userID"
-                Task.Delay(1000);
-                RemoveUserId(userId);
-            }
+                try
+                {
+                    BaseTest.McmClient.RemoveUserId(userId);
+                    removed = true;
+                }
+                catch (AlgoliaApiException)
+                {
+                    Task.Delay(1000).Wait();
+                }
+            } while (!removed);
         }
     }
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes (in tests)
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Need Doc update   | no


## Describe your change

We are getting a lot of CI failing with the following stack:
```
The active test run was aborted. Reason: Test host process crashed : Stack overflow.
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(System.Threading.Tasks.Task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task)
   at Algolia.Search.Utils.AsyncHelper.RunSync[[System.__Canon, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]](System.Func`1<System.Threading.Tasks.Task`1<System.__Canon>>)
   at Algolia.Search.Test.EndToEnd.Index.MultiClusterManagementTest.WaitUserId(System.String)
   at Algolia.Search.Test.EndToEnd.Index.MultiClusterManagementTest.WaitUserId(System.String)
   at Algolia.Search.Test.EndToEnd.Index.MultiClusterManagementTest.WaitUserId(System.String)
   at Algolia.Search.Test.EndToEnd.Index.MultiClusterManagementTest.WaitUserId(System.String)
   ...
```

This is because the `Task.Delay(1000)` was missing a `.Wait()`, and is currently not awaiting anything.
Thus, we are doing multiple recursive calls per second, so if the API doesn't reply quickly enough, a StackOverflow is triggered.

The fix is either to add `.Wait()` to the task, or to do a simple loop.
I did both 😎 
