### PR TITLE
feat: support `long` in IncrementSet/IncrementFrom

### DIFF
--- a/src/Algolia.Search.Test/Serializer/SerializerTest.cs
+++ b/src/Algolia.Search.Test/Serializer/SerializerTest.cs
@@ -679,7 +679,7 @@ namespace Algolia.Search.Test.Serializer
 
         [Test]
         [Parallelizable]
-        public void TestPartialUpdateOperation_IncrementFrom()
+        public void TestPartialUpdateOperation_IncrementFrom_int()
         {
             RecordWithPartialUpdateOperation<int> record = new RecordWithPartialUpdateOperation<int>
             {
@@ -693,12 +693,40 @@ namespace Algolia.Search.Test.Serializer
 
         [Test]
         [Parallelizable]
-        public void TestPartialUpdateOperation_IncrementSet()
+        public void TestPartialUpdateOperation_IncrementFrom_long()
+        {
+            RecordWithPartialUpdateOperation<long> record = new RecordWithPartialUpdateOperation<long>
+            {
+                ObjectID = "myID",
+                Update = PartialUpdateOperation<long>.IncrementFrom((long) 2),
+            };
+
+            string json = JsonConvert.SerializeObject(record, JsonConfig.AlgoliaJsonSerializerSettings);
+            Assert.AreEqual(json, "{\"objectID\":\"myID\",\"update\":{\"_operation\":\"IncrementFrom\",\"value\":2}}");
+        }
+
+        [Test]
+        [Parallelizable]
+        public void TestPartialUpdateOperation_IncrementSet_int()
         {
             RecordWithPartialUpdateOperation<int> record = new RecordWithPartialUpdateOperation<int>
             {
                 ObjectID = "myID",
                 Update = PartialUpdateOperation<int>.IncrementSet(2),
+            };
+
+            string json = JsonConvert.SerializeObject(record, JsonConfig.AlgoliaJsonSerializerSettings);
+            Assert.AreEqual(json, "{\"objectID\":\"myID\",\"update\":{\"_operation\":\"IncrementSet\",\"value\":2}}");
+        }
+
+        [Test]
+        [Parallelizable]
+        public void TestPartialUpdateOperation_IncrementSet_long()
+        {
+            RecordWithPartialUpdateOperation<long> record = new RecordWithPartialUpdateOperation<long>
+            {
+                ObjectID = "myID",
+                Update = PartialUpdateOperation<long>.IncrementSet((long) 2),
             };
 
             string json = JsonConvert.SerializeObject(record, JsonConfig.AlgoliaJsonSerializerSettings);

--- a/src/Algolia.Search.Test/Serializer/SerializerTest.cs
+++ b/src/Algolia.Search.Test/Serializer/SerializerTest.cs
@@ -698,7 +698,7 @@ namespace Algolia.Search.Test.Serializer
             RecordWithPartialUpdateOperation<long> record = new RecordWithPartialUpdateOperation<long>
             {
                 ObjectID = "myID",
-                Update = PartialUpdateOperation<long>.IncrementFrom((long) 2),
+                Update = PartialUpdateOperation<long>.IncrementFrom((long)2),
             };
 
             string json = JsonConvert.SerializeObject(record, JsonConfig.AlgoliaJsonSerializerSettings);
@@ -726,7 +726,7 @@ namespace Algolia.Search.Test.Serializer
             RecordWithPartialUpdateOperation<long> record = new RecordWithPartialUpdateOperation<long>
             {
                 ObjectID = "myID",
-                Update = PartialUpdateOperation<long>.IncrementSet((long) 2),
+                Update = PartialUpdateOperation<long>.IncrementSet((long)2),
             };
 
             string json = JsonConvert.SerializeObject(record, JsonConfig.AlgoliaJsonSerializerSettings);

--- a/src/Algolia.Search/Models/Search/PartialUpdateOperation.cs
+++ b/src/Algolia.Search/Models/Search/PartialUpdateOperation.cs
@@ -67,6 +67,16 @@ namespace Algolia.Search.Models.Search
             };
         }
 
+        ///<inheritdoc cref="IncrementFrom(int)"/>
+        public static PartialUpdateOperation<long> IncrementFrom(long value)
+        {
+            return new PartialUpdateOperation<long>
+            {
+                Operation = PartialUpdateOperationType.IncrementFrom,
+                Value = value,
+            };
+        }
+
         /// <summary>
         /// Increment a numeric integer attribute only if the provided value is greater than the current value, and otherwise ignore the whole object update
         /// </summary>
@@ -75,6 +85,16 @@ namespace Algolia.Search.Models.Search
         public static PartialUpdateOperation<int> IncrementSet(int value)
         {
             return new PartialUpdateOperation<int>
+            {
+                Operation = PartialUpdateOperationType.IncrementSet,
+                Value = value,
+            };
+        }
+
+        ///<inheritdoc cref="IncrementSet(int)"/>
+        public static PartialUpdateOperation<long> IncrementSet(long value)
+        {
+            return new PartialUpdateOperation<long>
             {
                 Operation = PartialUpdateOperationType.IncrementSet,
                 Value = value,


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | #775
| Need Doc update   | no


## Describe your change

Make built-in operations 'IncrementFrom' and 'IncrementSet' usable with `long`
