### PR TITLE
fix: optional filters deserialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,7 @@ _ReSharper*
 *.ncrunch*
 .*crunch*.local.xml
 
-# Installshield output folder 
+# Installshield output folder
 [Ee]xpress
 
 # DocProject is a documentation generator add-in
@@ -109,5 +109,6 @@ UpgradeLog*.XML
 *.nupkg
 
 # IDE
+.idea/
 .vscode/
 .vs/

--- a/src/Algolia.Search.Test/Serializer/SerializerTest.cs
+++ b/src/Algolia.Search.Test/Serializer/SerializerTest.cs
@@ -223,18 +223,22 @@ namespace Algolia.Search.Test.Serializer
 
             AssertOredResult(serializedNestedArrayFilter);
 
+            // Testing "one string with parenthesis" legacy filters => should be converted to "ORED" filters
+            // [["color:green", "color:yellow"], ["color:blue"]]
+            string stringParenthesisFilters = "\"(color:green,color:yellow),color:blue\"";
+
+            var serializedStringParenthesisFilters =
+                JsonConvert.DeserializeObject<List<List<string>>>(stringParenthesisFilters, new FiltersConverter());
+
+            AssertOredLatestResult(serializedStringParenthesisFilters);
+
             // Testing the latest format of filters i.e nested arrays
             string nestedAndedArrayFilters = "[[\"color:green\",\"color:yellow\"],[\"color:blue\"]]";
 
-            var serializedAdedNestedArrayFilter =
+            var serializedAndedNestedArrayFilter =
                 JsonConvert.DeserializeObject<List<List<string>>>(nestedAndedArrayFilters, new FiltersConverter());
 
-            Assert.That(serializedAdedNestedArrayFilter, Has.Count.EqualTo(2));
-            Assert.That(serializedAdedNestedArrayFilter.ElementAt(0), Has.Count.EqualTo(2));
-            Assert.That(serializedAdedNestedArrayFilter.ElementAt(0).ElementAt(0), Contains.Substring("color:green"));
-            Assert.That(serializedAdedNestedArrayFilter.ElementAt(0).ElementAt(1), Contains.Substring("color:yellow"));
-            Assert.That(serializedAdedNestedArrayFilter.ElementAt(1), Has.Count.EqualTo(1));
-            Assert.That(serializedAdedNestedArrayFilter.ElementAt(1).ElementAt(0), Contains.Substring("color:blue"));
+            AssertOredLatestResult(serializedAndedNestedArrayFilter);
 
             // Finally, testing that the custom reader is not breaking current implementation
             Rule ruleWithFilters = new Rule
@@ -301,6 +305,16 @@ namespace Algolia.Search.Test.Serializer
                 Assert.That(result.ElementAt(0).ElementAt(0), Contains.Substring("color:green"));
                 Assert.That(result.ElementAt(1), Has.Count.EqualTo(1));
                 Assert.That(result.ElementAt(1).ElementAt(0), Contains.Substring("color:yellow"));
+            }
+
+            void AssertOredLatestResult(List<List<string>> result)
+            {
+                Assert.That(result, Has.Count.EqualTo(2));
+                Assert.That(result.ElementAt(0), Has.Count.EqualTo(2));
+                Assert.That(result.ElementAt(0).ElementAt(0), Contains.Substring("color:green"));
+                Assert.That(result.ElementAt(0).ElementAt(1), Contains.Substring("color:yellow"));
+                Assert.That(result.ElementAt(1), Has.Count.EqualTo(1));
+                Assert.That(result.ElementAt(1).ElementAt(0), Contains.Substring("color:blue"));
             }
         }
 

--- a/src/Algolia.Search.Test/Serializer/SerializerTest.cs
+++ b/src/Algolia.Search.Test/Serializer/SerializerTest.cs
@@ -198,23 +198,23 @@ namespace Algolia.Search.Test.Serializer
         [Parallelizable]
         public void TestLegacyFilterFormats()
         {
-            // Testing "one string" legacy filters => should be converted to "ORED" nested filters
-            // [["color:green","color:yellow"]]
+            // Testing "one string" legacy filters => should be converted to "ANDED" nested filters
+            // [["color:green"],["color:yellow"]]
             string stringFilters = "\"color:green,color:yellow\"";
 
             var serializedStringFilters =
                 JsonConvert.DeserializeObject<List<List<string>>>(stringFilters, new FiltersConverter());
 
-            AssertOredResult(serializedStringFilters);
+            AssertAndedResult(serializedStringFilters);
 
-            // Testing "one array" legacy filters => should be converted to "ORED" nested filters
-            // [["color:green","color:yellow"]]
+            // Testing "one array" legacy filters => should be converted to "ANDED" nested filters
+            // [["color:green"],["color:yellow"]]
             string arrayFilters = "[\"color:green\",\"color:yellow\"]";
 
             var serializedArrayFilter =
                 JsonConvert.DeserializeObject<List<List<string>>>(arrayFilters, new FiltersConverter());
 
-            AssertOredResult(serializedArrayFilter);
+            AssertAndedResult(serializedArrayFilter);
 
             string nestedArrayFilters = "[[\"color:green\",\"color:yellow\"]]";
 
@@ -292,6 +292,15 @@ namespace Algolia.Search.Test.Serializer
                 Assert.That(result.ElementAt(0), Has.Count.EqualTo(2));
                 Assert.That(result.ElementAt(0).ElementAt(0), Contains.Substring("color:green"));
                 Assert.That(result.ElementAt(0).ElementAt(1), Contains.Substring("color:yellow"));
+            }
+
+            void AssertAndedResult(List<List<string>> result)
+            {
+                Assert.That(result, Has.Count.EqualTo(2));
+                Assert.That(result.ElementAt(0), Has.Count.EqualTo(1));
+                Assert.That(result.ElementAt(0).ElementAt(0), Contains.Substring("color:green"));
+                Assert.That(result.ElementAt(1), Has.Count.EqualTo(1));
+                Assert.That(result.ElementAt(1).ElementAt(0), Contains.Substring("color:yellow"));
             }
         }
 

--- a/src/Algolia.Search/Serializer/FiltersConverter.cs
+++ b/src/Algolia.Search/Serializer/FiltersConverter.cs
@@ -87,16 +87,20 @@ namespace Algolia.Search.Serializer
         }
 
         /** Build filters from (legacy) string */
-        private IEnumerable<List<string>> buildFilters(string str) {
+        private IEnumerable<List<string>> buildFilters(string str)
+        {
             // Extract groups: "(A:1,B:2),C:3" -> ["(A:1,B:2)","C:3"]
             var groups = System.Text.RegularExpressions.Regex.Split(str, ",(?![^()]*\\))");
             return groups.Select(group =>
             {
-                if (group.StartsWith("(") && group.EndsWith(")")) {
+                if (group.StartsWith("(") && group.EndsWith(")"))
+                {
                     var input = group.Substring(1, group.Length - 1);
                     return input.Split(',').ToList();
-                } else {
-                    return new List<string> {group};
+                }
+                else
+                {
+                    return new List<string> { group };
                 }
             });
         }

--- a/src/Algolia.Search/Serializer/FiltersConverter.cs
+++ b/src/Algolia.Search/Serializer/FiltersConverter.cs
@@ -67,7 +67,7 @@ namespace Algolia.Search.Serializer
                         case JTokenType.Null:
                             break;
                         case JTokenType.String:
-                            ret.Add(new List<string>{tokenValue.ToObject<string>()});
+                            ret.Add(new List<string> { tokenValue.ToObject<string>() });
                             break;
                         case JTokenType.Array:
                             var jArray = (JArray)tokenValue;

--- a/src/Algolia.Search/Serializer/FiltersConverter.cs
+++ b/src/Algolia.Search/Serializer/FiltersConverter.cs
@@ -67,7 +67,7 @@ namespace Algolia.Search.Serializer
                         case JTokenType.Null:
                             break;
                         case JTokenType.String:
-                            ret.AddRange(buildFilters(tokenValue.ToObject<string>()));
+                            ret.Add(new List<string>{tokenValue.ToObject<string>()});
                             break;
                         case JTokenType.Array:
                             var jArray = (JArray)tokenValue;


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | https://github.com/algolia/algoliasearch-client-java-2/pull/771
| Need Doc update   | no


## Description

Port the fix already made in the Java client: https://github.com/algolia/algoliasearch-client-java-2/pull/771

> Fixes `optionalFilters` deserialization for following special cases: 
> * `["A:1", "B:2"]` ->   `[["A:1"], ["B:2"]]`
> * `"A:1", "B:2"`  ->   `[["A:1"], ["B:2"]]`
