### PR TITLE
Add SourceLink and push symbols to NuGet.org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - optional filters deserialization (#803) ([5c4515c](https://github.com/algolia/algoliasearch-client-csharp/commit/5c4515c))
 
+### Feat
+
+- support NuGet.org debug symbols with SourceLink support, for better debugging experience (seamless step into).
+
 
 
 ## [6.12.0](https://github.com/algolia/algoliasearch-client-csharp/compare/6.11.0...6.12.0) (2021-11-05)

--- a/src/Algolia.Search/Algolia.Search.csproj
+++ b/src/Algolia.Search/Algolia.Search.csproj
@@ -23,8 +23,15 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TargetFrameworks>netstandard2.1;netstandard2.0;netstandard1.3</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <None Include="images\icon.png" Pack="true" PackagePath="\" />
   </ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup Condition="'$(CIRCLECI)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no     
| Related Issue     | 
| Need Doc update   | no


## Describe your change

The purpose of this change is to push debug symbols as a separate **.snupkg** to [NuGet.org](https://www.nuget.org/packages/Algolia.Search/).
This package can be retrieved by IDE (Visual Studio, VS Code) during debug, enabling stepping into source code with the help of SourceLink.
Using latest snupkg format.
ContinuousIntegrationBuild should be set during CI to avoid linking to paths from build vm, but not when built manually where local paths are relevant. (I couldn't easily test this part as I don't have access to a CircleCI platform, I am assuming that env variable CIRCLECI is set during CI)
Command `dotnet nuget push *.nupkg` should also push .snupkg if found.

## What problem is this fixing?

No debug info available for stack frame from algoliasearch-client-csharp when debugging.