### PR TITLE
fix: AlgoliaHelper.GetObjectID

### DIFF
--- a/src/Algolia.Search.Test/Utils/AlgoliaHelperTest.cs
+++ b/src/Algolia.Search.Test/Utils/AlgoliaHelperTest.cs
@@ -1,0 +1,42 @@
+using Algolia.Search.Utils;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+namespace Algolia.Search.Test.Utils;
+
+class TestRecord
+{
+    public string ObjectID { get; set; }
+    public string Name { get; set; }
+}
+
+[TestFixture]
+[Parallelizable]
+public class AlgoliaHelperTest
+{
+    [Test]
+    [Parallelizable]
+    public void TestGetObjectIdFromClass()
+    {
+        var objectId = "1-2_1-2";
+        var record = new TestRecord
+        {
+            ObjectID = objectId,
+            Name = "this is a test"
+        };
+        Assert.AreEqual(objectId, AlgoliaHelper.GetObjectID(record));
+    }
+
+    [Test]
+    [Parallelizable]
+    public void TestGetObjectIdFromJObject()
+    {
+        var objectId = "1-2_1-2";
+        var record = new JObject
+        {
+            { "objectID", objectId },
+            { "name", "this is a test" }
+        };
+        Assert.AreEqual(objectId, AlgoliaHelper.GetObjectID(record));
+    }
+}

--- a/src/Algolia.Search/Utils/AlgoliaHelper.cs
+++ b/src/Algolia.Search/Utils/AlgoliaHelper.cs
@@ -105,11 +105,11 @@ namespace Algolia.Search.Utils
 
             if (itemType == typeof(JObject))
             {
-                JProperty objectID = JObject.FromObject(data).Property("objectID");
+                var objectIdJProperty = JObject.FromObject(data).Property("objectID");
 
-                if (objectID != null && objectID.ToString() != "")
+                if (objectIdJProperty != null && !string.IsNullOrWhiteSpace(objectIdJProperty.Value.ToString()))
                 {
-                    return objectID.ToString();
+                    return objectIdJProperty.Value.ToString();
                 }
             }
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| Related Issue     | Fix #815
| Need Doc update   | no


## Describe your change

Reported by [jsancho](https://github.com/jsancho) in #815:
When called with a `JObject`, the `AlgoliaHelper.GetObjectID()` method was returning `"\"objectID\": \"my-object-id\""` instead of the objectID, making methods relying on it not working properly.
