### PR TITLE
feat: Add SourceLink and push symbols to NuGet.org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,6 @@
 
 - optional filters deserialization (#803) ([5c4515c](https://github.com/algolia/algoliasearch-client-csharp/commit/5c4515c))
 
-### Feat
-
-- support NuGet.org debug symbols with SourceLink support, for better debugging experience (seamless step into).
-
 
 
 ## [6.12.0](https://github.com/algolia/algoliasearch-client-csharp/compare/6.11.0...6.12.0) (2021-11-05)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 
 - optional filters deserialization (#803) ([5c4515c](https://github.com/algolia/algoliasearch-client-csharp/commit/5c4515c))
 
+### Feat
+
+- support NuGet.org debug symbols with SourceLink support, for better debugging experience (seamless step into).
+
 
 
 ## [6.12.0](https://github.com/algolia/algoliasearch-client-csharp/compare/6.11.0...6.12.0) (2021-11-05)

--- a/src/Algolia.Search/Algolia.Search.csproj
+++ b/src/Algolia.Search/Algolia.Search.csproj
@@ -23,8 +23,15 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TargetFrameworks>netstandard2.1;netstandard2.0;netstandard1.3</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <None Include="images\icon.png" Pack="true" PackagePath="\" />
   </ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
-  <PropertyGroup Condition="'$(CIRCLECI)' == 'true'">
+  <PropertyGroup Condition="'$(CI)' == 'true'">
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup Condition="'$(CIRCLECI)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Co-authored-by: Romain Hautefeuille (#806)

| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes


## Describe your change

Create and publish symbol packages (.snupkg) with Source Link.
Source Link documentation:
https://devblogs.microsoft.com/dotnet/producing-packages-with-source-link/
https://github.com/dotnet/sourcelink

## What problem is this fixing?

https://learn.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg
> A good debugging experience relies on the presence of debug symbols as they provide critical information like the association between the compiled and the source code, names of local variables, stack traces, and more. You can use symbol packages (.snupkg) to distribute these symbols and improve the debugging experience of your NuGet packages.
