### PR TITLE
fix: serialization of AroundPrecision property

### DIFF
--- a/src/Algolia.Search.Test/Serializer/SerializerTest.cs
+++ b/src/Algolia.Search.Test/Serializer/SerializerTest.cs
@@ -21,7 +21,6 @@
 * THE SOFTWARE.
 */
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Algolia.Search.Models.Common;
@@ -89,7 +88,6 @@ namespace Algolia.Search.Test.Serializer
         {
             var queryWithAroundPrecisionList = new Query("") { AroundPrecision = new List<AroundPrecision> { new() { From = 0, Value = 10 }, new() { From = 1000, Value = 100 } } };
             // Expected: query=&aroundPrecision=[{"from":0,"value": 10},{"from":1000,"value": 100}]
-            Console.WriteLine(queryWithAroundPrecisionList.ToQueryString());
             Assert.AreEqual("query=&aroundPrecision=%5B%7B%22from%22%3A0%2C%22value%22%3A10%7D%2C%7B%22from%22%3A1000%2C%22value%22%3A100%7D%5D", queryWithAroundPrecisionList.ToQueryString());
         }
 

--- a/src/Algolia.Search.Test/Serializer/SerializerTest.cs
+++ b/src/Algolia.Search.Test/Serializer/SerializerTest.cs
@@ -87,7 +87,7 @@ namespace Algolia.Search.Test.Serializer
         [Parallelizable]
         public void TestQueryWithAroundPrecision()
         {
-            var queryWithAroundPrecisionList = new Query("") { AroundPrecision = new List<AroundPrecision> { new(){ From = 0, Value = 10}, new(){ From = 1000, Value = 100}} };
+            var queryWithAroundPrecisionList = new Query("") { AroundPrecision = new List<AroundPrecision> { new() { From = 0, Value = 10 }, new() { From = 1000, Value = 100 } } };
             // Expected: query=&aroundPrecision=[{"from":0,"value": 10},{"from":1000,"value": 100}]
             Console.WriteLine(queryWithAroundPrecisionList.ToQueryString());
             Assert.AreEqual("query=&aroundPrecision=%5B%7B%22from%22%3A0%2C%22value%22%3A10%7D%2C%7B%22from%22%3A1000%2C%22value%22%3A100%7D%5D", queryWithAroundPrecisionList.ToQueryString());

--- a/src/Algolia.Search.Test/Serializer/SerializerTest.cs
+++ b/src/Algolia.Search.Test/Serializer/SerializerTest.cs
@@ -21,6 +21,7 @@
 * THE SOFTWARE.
 */
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Algolia.Search.Models.Common;
@@ -80,6 +81,16 @@ namespace Algolia.Search.Test.Serializer
         {
             Query query = new Query("") { Distinct = 0 };
             Assert.AreEqual(query.ToQueryString(), "query=&distinct=0");
+        }
+
+        [Test]
+        [Parallelizable]
+        public void TestQueryWithAroundPrecision()
+        {
+            var queryWithAroundPrecisionList = new Query("") { AroundPrecision = new List<AroundPrecision> { new(){ From = 0, Value = 10}, new(){ From = 1000, Value = 100}} };
+            // Expected: query=&aroundPrecision=[{"from":0,"value": 10},{"from":1000,"value": 100}]
+            Console.WriteLine(queryWithAroundPrecisionList.ToQueryString());
+            Assert.AreEqual("query=&aroundPrecision=%5B%7B%22from%22%3A0%2C%22value%22%3A10%7D%2C%7B%22from%22%3A1000%2C%22value%22%3A100%7D%5D", queryWithAroundPrecisionList.ToQueryString());
         }
 
         [Test]

--- a/src/Algolia.Search/Models/Search/AroundPrecision.cs
+++ b/src/Algolia.Search/Models/Search/AroundPrecision.cs
@@ -27,6 +27,7 @@ namespace Algolia.Search.Models.Search
     /// Precision of geo search (in meters), to add grouping by geo location to the ranking formula.
     /// https://www.algolia.com/doc/api-reference/api-parameters/aroundPrecision/
     /// </summary>
+    [SerializeIntoUrl]
     public class AroundPrecision
     {
         /// <summary>

--- a/src/Algolia.Search/Models/Search/SerializeIntoUrlAttribute.cs
+++ b/src/Algolia.Search/Models/Search/SerializeIntoUrlAttribute.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Algolia.Search.Models.Search
+{
+    /// <summary>
+    /// Mark a Poco as Serializable into URL
+    /// </summary>
+    class SerializeIntoUrlAttribute : Attribute
+    {
+    }
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | --
| Need Doc update   | yes

## Describe your change

following new feat #578, the search query was not correctly serialized.

```&aroundPrecision=Algolia.Search.Models.Search.AroundPrecision%2CAlgolia.Search.Models.Search.AroundPrecision"```

## What problem is this fixing?

If `aroundPrecision` property is set, the search query does not correctly reflect the user inputs.
