### PR TITLE
fix: multi indices search serialization

### DIFF
--- a/src/Algolia.Search/Models/Common/MultipleQueriesRequest.cs
+++ b/src/Algolia.Search/Models/Common/MultipleQueriesRequest.cs
@@ -36,7 +36,7 @@ namespace Algolia.Search.Models.Common
         /// <summary>
         /// List of requests
         /// </summary>
-        public IEnumerable<MultipleQueries> Requests { get; set; }
+        public IEnumerable<IMultipleQueries> Requests { get; set; }
 
         /// <summary>
         /// Request strategy <see cref="Enums.StrategyType"/>
@@ -45,9 +45,14 @@ namespace Algolia.Search.Models.Common
     }
 
     /// <summary>
+    /// Multiple queries interface
+    /// </summary>
+    public interface IMultipleQueries { }
+
+    /// <summary>
     /// Multiple queries
     /// </summary>
-    public class MultipleQueries
+    public class MultipleQueries: IMultipleQueries
     {
         /// <summary>
         /// The name of the index to perform the operation

--- a/src/Algolia.Search/Models/Search/QueryMultiIndices.cs
+++ b/src/Algolia.Search/Models/Search/QueryMultiIndices.cs
@@ -1,0 +1,27 @@
+using Algolia.Search.Models.Common;
+
+namespace Algolia.Search.Models.Search
+{
+    /// <summary>
+    /// For more information regarding the parameters
+    /// https://www.algolia.com/doc/api-reference/search-api-parameters/
+    /// </summary>
+    public class QueryMultiIndices : Query, IMultipleQueries
+    {
+        /// <summary>
+        /// Create a new query with an empty search query, for a dedicated indice,
+        /// </summary>
+        /// <param name="indexName"></param>
+        /// <param name="searchQuery"></param>
+        public QueryMultiIndices(string indexName, string searchQuery = null)
+        {
+            IndexName = indexName;
+            SearchQuery = searchQuery;
+        }
+
+        /// <summary>
+        /// The name of the index to perform the operation
+        /// </summary>
+        public string IndexName { get; set; }
+    }
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no   
| BC breaks?        | no     
| Related Issue     | ---
| Need Doc update   | no


## Describe your change

Algolia Search API for MultiQuery (```/1/indexes/*/queries```) accepts query parameters as a url-encoded string or directly by serializing the ```Query``` object. This PR add the option to use the ```Query``` serialization instead of the url-encoded.

## What problem is this fixing?
The url-encoded query parameter do not work correctly for geo-location property and ```CustomParameters```.
