### PR TITLE
fix: remove encoding on attributes to retrieve

### DIFF
--- a/src/Algolia.Search/Clients/SearchIndex.cs
+++ b/src/Algolia.Search/Clients/SearchIndex.cs
@@ -516,7 +516,7 @@ namespace Algolia.Search.Clients
             {
                 var dic = new Dictionary<string, string>
                 {
-                    {nameof(attributesToRetrieve), WebUtility.UrlEncode(string.Join(",", attributesToRetrieve))}
+                    { nameof(attributesToRetrieve), string.Join(",", attributesToRetrieve.Select(x => x.Trim())) }
                 };
 
                 requestOptions = requestOptions.AddQueryParams(dic);


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Need Doc update   | no

## Describe your change

Remove encoding at the route level and let the query builder helper encode correctly the URI.

## What problem is this fixing?

When passing `attributesToRetrieve` property when using `GetObjectAsync`, query parameters were double-encoded.