### PR TITLE
Avoid some List allocations and resizes

### DIFF
--- a/src/Algolia.Search/Models/Batch/BatchRequest.cs
+++ b/src/Algolia.Search/Models/Batch/BatchRequest.cs
@@ -59,7 +59,15 @@ namespace Algolia.Search.Models.Batch
                 throw new ArgumentNullException(nameof(data));
             }
 
-            Operations = new List<BatchOperation<T>>();
+            if (data is IReadOnlyCollection<T> dataCollection)
+            {
+                // If it is a collection, we can avoid resizing the Operations list from 4->8->16->32->64->128->256->512->1024 for the default max batch size
+                Operations = new List<BatchOperation<T>>(dataCollection.Count);
+            }
+            else
+            {
+                Operations = new List<BatchOperation<T>>();
+            }
 
             foreach (var item in data)
             {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no, performance improvement
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | no
| Need Doc update   | no


## Describe your change

Profiling my application, `SplitIntoBatchesAsync` showed up and I spotted room for improvement.

**SplitIntoBatchesAsync**
Before, a new List was allocated and data copied, even though batch size is below max.

If we can get the size of the batch and it is below max batch size, no new allocations & copying happens and the data is used directly.

If the batch size is over max batch size, resizing the records list from 4->8->16->32->64->128->256->512->1024 is avoided.  
Resizing the list involves allocating new arrays for the mentioned capacities and copying the data over.  
Instead one array of max batch size is allocated.  
If `batch size % max batch size != 0` an array is allocated for the last batch.

`BatchRequest`
If we can get the size of the data, the Operations List is initiated with the size, so resizing it from 4->8->16->32->64->128->256->512->1024 for max batch size is avoided.

## What problem is this fixing?

This will avoid allocations & resizing of records for batches smaller than max batch size for all collections.

Resizing lists will be avoided for `SplitIntoBatchesAsync` & `BatchRequest` for all collections of batches & data.

This will reduce resources spent on allocating, resizing, memory pressure & garbage collection for these operations.  
Thereby increasing the perceived performance of algolia.  
And lowering the environmental footprint of users of this SDK
